### PR TITLE
Handle OpenSearch ConnectionTimeout with user-friendly 504 error

### DIFF
--- a/timesketch/api/v1/resources/explore.py
+++ b/timesketch/api/v1/resources/explore.py
@@ -39,8 +39,10 @@ from timesketch.lib.utils import get_validated_indices
 from timesketch.lib.definitions import DEFAULT_SOURCE_FIELDS
 from timesketch.lib.definitions import HTTP_STATUS_CODE_BAD_REQUEST
 from timesketch.lib.definitions import HTTP_STATUS_CODE_FORBIDDEN
+from timesketch.lib.definitions import HTTP_STATUS_CODE_GATEWAY_TIMEOUT
 from timesketch.lib.definitions import HTTP_STATUS_CODE_NOT_FOUND
 from timesketch.lib.definitions import METRICS_NAMESPACE
+from timesketch.lib.errors import DatastoreTimeoutError
 from timesketch.models import db_session
 from timesketch.models.sketch import Event
 from timesketch.models.sketch import Sketch
@@ -238,6 +240,8 @@ class ExploreResource(resources.ResourceMixin, Resource):
                     timeline_ids=timeline_ids,
                     count=True,
                 )
+            except DatastoreTimeoutError as e:
+                abort(HTTP_STATUS_CODE_GATEWAY_TIMEOUT, str(e))
             except ValueError as e:
                 abort(HTTP_STATUS_CODE_BAD_REQUEST, str(e))
 
@@ -290,6 +294,8 @@ class ExploreResource(resources.ResourceMixin, Resource):
                     enable_scroll=enable_scroll,
                     timeline_ids=timeline_ids,
                 )
+            except DatastoreTimeoutError as e:
+                abort(HTTP_STATUS_CODE_GATEWAY_TIMEOUT, str(e))
             except ValueError as e:
                 abort(HTTP_STATUS_CODE_BAD_REQUEST, str(e))
 

--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -81,11 +81,22 @@ limitations under the License.
       </v-card>
     </v-dialog>
 
-    <div v-if="!eventList.objects.length && !searchInProgress && !currentQueryString">
+    <div v-if="searchError && !searchInProgress" class="pa-4">
+      <v-alert
+        type="error"
+        outlined
+        text
+      >
+        <div class="title">Search Failed</div>
+        <div>{{ searchError }}</div>
+      </v-alert>
+    </div>
+
+    <div v-if="!eventList.objects.length && !searchInProgress && !currentQueryString && !searchError">
       <ts-explore-welcome-card></ts-explore-welcome-card>
     </div>
 
-    <div v-if="!eventList.objects.length && !searchInProgress && currentQueryString" class="ml-3">
+    <div v-if="!eventList.objects.length && !searchInProgress && currentQueryString && !searchError" class="ml-3">
       <ts-search-not-found-card
         :currentQueryString="currentQueryString"
         :filterChips="filterChips"
@@ -640,6 +651,7 @@ export default {
       summaryCollapsed: false,
       showBanner: false,
       showExportLimitDialog: false,
+      searchError: '',
     }
   },
   computed: {
@@ -886,6 +898,7 @@ export default {
       this.searchInProgress = true
       this.selectedEvents = []
       this.eventList = emptyEventList()
+      this.searchError = ''
 
       if (resetPagination) {
         this.tableOptions.page = 1
@@ -956,6 +969,7 @@ export default {
           }
         })
         .catch((e) => {
+          this.searchInProgress = false
           let msg = 'Sorry, there was a problem fetching your search results. Error: "' + e.response.data.message + '"'
           if (
             e.response.data.message.includes('too_many_nested_clauses') ||
@@ -967,6 +981,7 @@ export default {
           } else {
             this.errorSnackBar(msg)
           }
+          this.searchError = msg
           console.error('Error message: ' + msg)
           console.error(e)
         })

--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -81,15 +81,10 @@ limitations under the License.
       </v-card>
     </v-dialog>
 
-    <div v-if="searchError && !searchInProgress" class="pa-4">
-      <v-alert
-        type="error"
-        outlined
-        text
-      >
-        <div class="title">Search Failed</div>
-        <div>{{ searchError }}</div>
-      </v-alert>
+    <div v-if="searchError && !searchInProgress" class="ml-3">
+      <ts-search-error-card
+        :error-text="searchError"
+      ></ts-search-error-card>
     </div>
 
     <div v-if="!eventList.objects.length && !searchInProgress && !currentQueryString && !searchError">
@@ -528,6 +523,7 @@ import TsEventActionMenu from './EventActionMenu.vue'
 import TsEventTags from './EventTags.vue'
 import TsExploreWelcomeCard from './ExploreWelcomeCard.vue'
 import TsSearchNotFoundCard from './SearchNotFoundCard.vue'
+import TsSearchErrorCard from './SearchErrorCard.vue'
 
 const defaultQueryFilter = () => {
   return {
@@ -560,6 +556,7 @@ export default {
     TsEventTags,
     TsExploreWelcomeCard,
     TsSearchNotFoundCard,
+    TsSearchErrorCard,
   },
   mixins: [EventMixin],
   props: {

--- a/timesketch/frontend-ng/src/components/Explore/SearchErrorCard.vue
+++ b/timesketch/frontend-ng/src/components/Explore/SearchErrorCard.vue
@@ -1,0 +1,85 @@
+<!--
+Copyright 2025 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<template>
+  <ts-search-guide-card
+    :flat="inDialog"
+    :show-tags="showTags"
+    :show-data-types="showDataTypes"
+    :show-saved-searches="showSavedSearches"
+  >
+    <template v-slot:header>
+      <div class="pa-4 pb-0">
+        <v-card-title>
+          <v-icon large left color="error">mdi-alert-circle-outline</v-icon>
+          Search Failed
+          <v-spacer></v-spacer>
+          <v-btn v-if="inDialog" icon @click="$emit('close-dialog')" title="Close dialog">
+            <v-icon>mdi-close</v-icon>
+          </v-btn>
+        </v-card-title>
+        <v-card-subtitle class="mt-1">
+          <p>
+            {{ errorText }}
+          </p>
+          <p>Suggestions:</p>
+          <ul>
+            <li>Try different keywords.</li>
+            <li>Try more general keywords.</li>
+            <li>Try fewer keywords.</li>
+            <li>Try some of the search examples below.</li>
+          </ul>
+        </v-card-subtitle>
+        <v-divider></v-divider>
+      </div>
+    </template>
+  </ts-search-guide-card>
+</template>
+
+<script>
+import TsSearchGuideCard from './SearchGuideCard.vue'
+
+export default {
+  name: 'TsSearchErrorCard',
+  props: {
+    inDialog: {
+      type: Boolean,
+      default: false,
+    },
+    errorText: {
+      type: String,
+      default: 'An unknown error occurred.',
+    },
+  },
+  components: {
+    TsSearchGuideCard,
+  },
+  computed: {
+    showTags() {
+      if (!this.$store.state.tags || !this.$store.state.meta.filter_labels) return false
+      const filteredLabels = this.$store.state.meta.filter_labels.filter(
+        (labelObj) => !labelObj.label.startsWith('__ts_fact')
+      )
+      return [...this.$store.state.tags, ...filteredLabels].length > 0
+    },
+    showDataTypes() {
+      return this.$store.state.dataTypes.length > 0
+    },
+    showSavedSearches() {
+      return this.$store.state.meta.views.length > 0
+    },
+  },
+}
+</script>

--- a/timesketch/lib/datastores/opensearch_test.py
+++ b/timesketch/lib/datastores/opensearch_test.py
@@ -1,0 +1,57 @@
+# Copyright 2025 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for OpenSearch datastore."""
+
+from unittest import mock
+from opensearchpy.exceptions import ConnectionTimeout
+
+from timesketch.lib.datastores.opensearch import OpenSearchDataStore
+from timesketch.lib.testlib import BaseTest
+from timesketch.lib.errors import DatastoreTimeoutError
+
+
+class OpenSearchDataStoreTest(BaseTest):
+    """Tests for OpenSearchDataStore."""
+
+    @mock.patch("timesketch.lib.datastores.opensearch.current_user")
+    @mock.patch("timesketch.lib.datastores.opensearch.OpenSearch")
+    def test_search_timeout(self, mock_client, mock_user):
+        """Test that search raises DatastoreTimeoutError on ConnectionTimeout."""
+        mock_user.username = "testuser"
+
+        # Setup mock client to raise ConnectionTimeout
+        mock_es_instance = mock_client.return_value
+        mock_es_instance.search.side_effect = ConnectionTimeout(
+            "Timeout", "Timeout", "Timeout"
+        )
+
+        # Initialize datastore (mocking config is handled by BaseTest/TestConfig)
+        ds = OpenSearchDataStore(host="127.0.0.1", port=9200)
+
+        # Ensure the client in the datastore is indeed our mock (it should be)
+        ds.client = mock_es_instance
+
+        # Test generic timeout message
+        with self.assertRaises(DatastoreTimeoutError) as cm:
+            ds.search(sketch_id=1, indices=["test"], query_string="test")
+
+        self.assertIn("The search timed out", str(cm.exception))
+        self.assertIn("Try to narrow down your search", str(cm.exception))
+
+        # Test wildcard specific message
+        with self.assertRaises(DatastoreTimeoutError) as cm:
+            ds.search(sketch_id=1, indices=["test"], query_string="*test")
+
+        self.assertIn("The search timed out", str(cm.exception))
+        self.assertIn("avoid leading wildcards", str(cm.exception))

--- a/timesketch/lib/errors.py
+++ b/timesketch/lib/errors.py
@@ -59,3 +59,7 @@ class DatastoreConnectionError(Error):
 
 class DatastoreQueryError(Error):
     """Error with the datastore query."""
+
+
+class DatastoreTimeoutError(Error):
+    """Error with the datastore timeout."""


### PR DESCRIPTION
Handle OpenSearch ConnectionTimeout with user-friendly 504 error

When an OpenSearch query times out, the backend now catches the `ConnectionTimeout` exception, logs a descriptive error, and raises a `DatastoreTimeoutError`. The API layer catches this error and returns a 504 Gateway Timeout response with a helpful message advising the user to narrow down their search or avoid expensive operations like leading wildcards.

This prevents the generic 500 Internal Server Error and provides actionable feedback to the user.

- Added `DatastoreTimeoutError` to `timesketch/lib/errors.py`.
- Updated `timesketch/lib/datastores/opensearch.py` to catch `ConnectionTimeout` and raise `DatastoreTimeoutError`.
- Updated `timesketch/api/v1/resources/explore.py` to catch `DatastoreTimeoutError` and abort with 504.
- Added `timesketch/lib/datastores/opensearch_test.py` to test the datastore logic.
- Updated `timesketch/api/v1/resources_test.py` to test the API response.

---
*PR created automatically by Jules for task [17934926470249191559](https://jules.google.com/task/17934926470249191559) started by @jkppr*