### PR TITLE
Add backend versions to tsctl info

### DIFF
--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -950,6 +950,33 @@ def info():
     except FileNotFoundError:
         print("pip not installed")
 
+    # Get OpenSearch version
+    try:
+        es = OpenSearchDataStore()
+        print(f"OpenSearch version: {es.version}")
+    except Exception as e:  # pylint: disable=broad-except
+        print(f"OpenSearch: Not running or not configured ({e})")
+
+    # Get Redis version
+    try:
+        celery = create_celery_app()
+        redis_url = celery.conf.broker_url
+        redis_client = redis.from_url(redis_url)
+        print(f"Redis version: {redis_client.info()['redis_version']}")
+    except Exception as e:  # pylint: disable=broad-except
+        print(f"Redis: Not running or not configured ({e})")
+
+    # Get Postgres version
+    try:
+        db_uri = current_app.config.get("SQLALCHEMY_DATABASE_URI", "")
+        if "postgresql" in db_uri:
+            version_row = db_session.execute(sqlalchemy.text("SELECT version();")).fetchone()
+            print(f"Postgres version: {version_row[0]}")
+        else:
+            print("Database: Not using PostgreSQL")
+    except Exception as e:  # pylint: disable=broad-except
+        print(f"Database: Error getting version ({e})")
+
 
 def print_table(table_data):
     """Prints a table."""


### PR DESCRIPTION
Enhanced `tsctl info` command to display versions of key backend components: OpenSearch, Redis, and PostgreSQL. This aids in debugging and environment verification. The checks are implemented with try-except blocks to ensure the command remains usable even if some services are down or misconfigured.

---
*PR created automatically by Jules for task [4144785128149562885](https://jules.google.com/task/4144785128149562885) started by @jkppr*