### PR TITLE
Support Plaso event filters in import client

### DIFF
--- a/end_to_end_tests/import_plaso_filter_test.py
+++ b/end_to_end_tests/import_plaso_filter_test.py
@@ -1,0 +1,102 @@
+# Copyright 2025 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End to end tests of Timesketch upload functionality with filter."""
+
+import uuid
+import os
+import time
+from . import interface
+from . import manager
+from timesketch_import_client import importer
+
+class ImportPlasoFilterTest(interface.BaseEndToEndTest):
+    """End to end tests for plaso upload functionality with filter."""
+
+    NAME = "import_plaso_filter_test"
+
+    def import_timeline(self, filename, index_name=None, sketch=None, filter_expression=None):
+        """Import a Plaso file with an optional filter.
+
+        Args:
+            filename (str): Filename of the file to be imported.
+            index_name (str): The OpenSearch index to store the documents in.
+            sketch (Sketch): Optional sketch object to add the timeline to.
+            filter_expression (str): Plaso event filter expression.
+
+        Returns:
+            The created timeline object.
+        """
+        if not sketch:
+            sketch = self.sketch
+
+        file_path = os.path.join(interface.TEST_DATA_DIR, filename)
+        if not index_name:
+            index_name = uuid.uuid4().hex
+
+        with importer.ImportStreamer() as streamer:
+            streamer.set_sketch(sketch)
+            streamer.set_timeline_name(f"{file_path}_{filter_expression}")
+            streamer.set_index_name(index_name)
+            streamer.set_provider("e2e test interface")
+            if filter_expression:
+                streamer.set_plaso_event_filter(filter_expression)
+            streamer.add_file(file_path)
+            timeline = streamer.timeline
+
+        # Poll for readiness (simplified from base class for this specific test)
+        max_retries = 30
+        for _ in range(max_retries):
+            try:
+                if timeline:
+                    timeline.lazyload_data(refresh_cache=True)
+                    if timeline.status == "ready":
+                        break
+                    if timeline.status == "fail":
+                         raise RuntimeError(f"Timeline failed processing: {timeline.status}")
+            except Exception:
+                pass
+            time.sleep(2)
+
+        return timeline
+
+    def test_plaso_import_with_filter(self):
+        """Test the upload of a plaso file with a filter."""
+        # create a new sketch
+        rand = uuid.uuid4().hex
+        sketch = self.api.create_sketch(name=f"test_plaso_filter_import_{rand}")
+        self.sketch = sketch
+
+        file_name = "evtx_20250918.plaso"
+
+        # This filter should limit the number of events.
+        # Original file has 3205 events.
+        # We'll filter for a specific event identifier or attribute common in the file to reduce count.
+        # For this test, we just check that the import succeeds with a filter.
+        # A valid simple filter for plaso/psort: "parser:winevtx" (should be all of them)
+        # or something more specific if we knew the content.
+        # Let's try a filter that we know works syntactically.
+        filter_expression = "parser:winevtx"
+
+        timeline = self.import_timeline(file_name, sketch=sketch, filter_expression=filter_expression)
+
+        # check that timeline was uploaded correctly
+        self.assertions.assertIsNotNone(timeline)
+        self.assertions.assertEqual(timeline.index.status, "ready")
+
+        events = sketch.explore("*", as_pandas=True)
+        # Verify events are present. Exact count depends on filter, but here we just check it worked.
+        self.assertions.assertTrue(len(events) > 0)
+
+
+manager.EndToEndTestManager.register_test(ImportPlasoFilterTest)

--- a/importer_client/python/timesketch_import_client/importer.py
+++ b/importer_client/python/timesketch_import_client/importer.py
@@ -106,6 +106,7 @@ class ImportStreamer(object):
         self._timeline_id = None
         self._timeline_name = None
         self._upload_context = ""
+        self._plaso_event_filter = None
 
         self._chunk = 1
 
@@ -562,6 +563,9 @@ class ImportStreamer(object):
         if self._upload_context:
             data["context"] = self._upload_context
 
+        if self._plaso_event_filter:
+            data["plaso_event_filter"] = self._plaso_event_filter
+
         if file_size <= self._threshold_filesize:
             with open(file_path, "rb") as fh:
                 file_dict = {"file": fh}
@@ -808,6 +812,12 @@ class ImportStreamer(object):
         if not self._data_label:
             self._data_label = file_ending
 
+        if self._plaso_event_filter and file_ending != "plaso":
+            logger.warning(
+                "Plaso event filter set, but file extension is not plaso. "
+                "The filter will be ignored."
+            )
+
         if file_ending == "csv":
             if self._csv_delimiter:
                 delimiter = self._csv_delimiter
@@ -987,6 +997,10 @@ class ImportStreamer(object):
     def set_upload_context(self, upload_context):
         """Set the upload context for the data import."""
         self._upload_context = upload_context
+
+    def set_plaso_event_filter(self, event_filter):
+        """Set the event filter for the Plaso file."""
+        self._plaso_event_filter = event_filter
 
     def generate_index_name(self):
         """Generates a new index name."""

--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -139,6 +139,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
         meta: Optional[Dict] = None,
         headers_mapping: Optional[List] = None,
         delimiter: str = ",",
+        plaso_event_filter: str = "",
     ):
         """Creates a full pipeline for an uploaded file and returns the results.
 
@@ -163,6 +164,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
                              (iii) def. value if we add a new column [key=default_value]
 
             delimiter: delimiter to read the CSV file
+            plaso_event_filter: filter string for Plaso files.
 
         Returns:
             A timeline if created otherwise a search index in JSON (instance
@@ -220,6 +222,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
                 meta=meta,
                 headers_mapping=headers_mapping,
                 delimiter=delimiter,
+                plaso_event_filter=plaso_event_filter,
             )
 
         if not timeline:
@@ -284,6 +287,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
             timeline_id=timeline.id,
             headers_mapping=headers_mapping,
             delimiter=delimiter,
+            plaso_event_filter=plaso_event_filter,
         )
         task_id = uuid.uuid4().hex
         pipeline.apply_async(task_id=task_id)
@@ -331,6 +335,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
         chunk_index_name: str = "",
         headers_mapping: Optional[List] = None,
         delimiter: str = ",",
+        plaso_event_filter: str = "",
     ):
         """Uploads a file to Timesketch, handling both single files and file chunks.
 
@@ -364,6 +369,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
                 - headersMapping (str, optional): JSON string of header mapping.
                 - delimiter (str, optional): delimiter to read the CSV file.
                     Defaults to ",".
+                - plaso_event_filter (str, optional): Plaso event filter.
             sketch: The Sketch object to which the timeline will be added.
             index_name: The name of the OpenSearch index for the timeline.
             chunk_index_name: A unique identifier for the file if chunks are
@@ -375,6 +381,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
                 - default_value (str, optional): A default value if a new
                     column is added.
             delimiter: delimiter to read the CSV file
+            plaso_event_filter: filter string for Plaso files.
 
         Returns:
             A JSON response (flask.wrappers.Response) indicating the status
@@ -455,6 +462,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
                 enable_stream=enable_stream,
                 headers_mapping=headers_mapping,
                 delimiter=delimiter,
+                plaso_event_filter=plaso_event_filter,
             )
 
         # For file chunks we need the correct filepath, otherwise each chunk
@@ -530,6 +538,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
             meta=meta,
             headers_mapping=headers_mapping,
             delimiter=delimiter,
+            plaso_event_filter=plaso_event_filter,
         )
 
     @login_required
@@ -581,6 +590,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
         utils.update_sketch_last_activity(sketch)
 
         index_name = form.get("index_name", "")
+        plaso_event_filter = form.get("plaso_event_filter", "")
         file_storage = request.files.get("file")
         if file_storage:
             chunk_index_name = form.get("chunk_index_name", uuid.uuid4().hex)
@@ -592,6 +602,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
                 index_name=index_name,
                 headers_mapping=headers_mapping,
                 delimiter=delimiter,
+                plaso_event_filter=plaso_event_filter,
             )
 
         events = form.get("events")

--- a/timesketch/lib/tasks_test.py
+++ b/timesketch/lib/tasks_test.py
@@ -1,0 +1,166 @@
+# Copyright 2025 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for tasks."""
+
+import sys
+from unittest import mock
+
+# Mock timesketch.app.create_celery_app before importing timesketch.lib.tasks
+# because timesketch.lib.tasks calls create_celery_app() at module level.
+import timesketch.app
+
+mock_celery = mock.MagicMock()
+def task_decorator(*args, **kwargs):
+    def decorator(f):
+        return f
+    return decorator
+mock_celery.task = task_decorator
+# Mock celery.Task so SqlAlchemyTask can inherit from it
+mock_celery.Task = object
+
+timesketch.app.create_celery_app = mock.Mock(return_value=mock_celery)
+
+from timesketch.lib.testlib import BaseTest
+from timesketch.lib import tasks
+
+class TestTasks(BaseTest):
+    """Tests for the tasks."""
+
+    def setUp(self):
+        super().setUp()
+        # Inject pinfo_tool into tasks module if it doesn't exist (because plaso missing)
+        if not hasattr(tasks, "pinfo_tool"):
+            tasks.pinfo_tool = mock.MagicMock()
+
+    @mock.patch("timesketch.lib.tasks.db_session")
+    @mock.patch("timesketch.lib.tasks.plaso")
+    @mock.patch("timesketch.lib.tasks.subprocess.check_output")
+    @mock.patch("timesketch.lib.tasks.OpenSearchDataStore")
+    @mock.patch("timesketch.lib.tasks.SearchIndex")
+    @mock.patch("timesketch.lib.tasks._set_datasource_status")
+    @mock.patch("timesketch.lib.tasks._set_datasource_total_events")
+    def test_run_plaso_with_filter(
+        self,
+        mock_set_total_events,
+        mock_set_status,
+        mock_search_index,
+        mock_datastore,
+        mock_subprocess,
+        mock_plaso,
+        mock_db_session,
+    ):
+        """Test run_plaso task with a filter."""
+        # Setup mocks
+        mock_plaso.__version__ = "20220101"
+
+        # Configure pinfo_tool mock
+        mock_pinfo_instance = tasks.pinfo_tool.PinfoTool.return_value
+        mock_storage_reader = mock.Mock()
+        mock_pinfo_instance._GetStorageReader.return_value = mock_storage_reader
+        mock_pinfo_instance._CalculateStorageCounters.return_value = {
+            "parsers": {"total": 100}
+        }
+
+        # Configure SearchIndex mock
+        mock_index_obj = mock.MagicMock()
+        mock_search_index.query.filter_by.return_value.first.return_value = mock_index_obj
+
+        # Configure OpenSearchDataStore mock
+        mock_datastore_instance = mock_datastore.return_value
+        mock_datastore_instance.client.indices.exists.return_value = True
+        mock_datastore_instance.create_index.return_value = "test_index"
+
+        mock_connection = mock.Mock()
+        mock_connection.host = "http://localhost:9200"
+        mock_connection.port = 9200
+        mock_datastore_instance.client.transport.get_connection.return_value = mock_connection
+
+        # Run the task
+        tasks.run_plaso(
+            file_path="/tmp/test.plaso",
+            events="",
+            timeline_name="test_timeline",
+            index_name="test_index",
+            source_type="plaso",
+            timeline_id=1,
+            plaso_event_filter="parser:syslog",
+        )
+
+        # Verify that subprocess was called with the filter
+        self.assertTrue(mock_subprocess.called, "subprocess.check_output was not called")
+        args, _ = mock_subprocess.call_args
+        cmd_list = args[0]
+
+        self.assertIn("parser:syslog", cmd_list)
+        self.assertEqual(cmd_list[-1], "parser:syslog")
+
+    @mock.patch("timesketch.lib.tasks.db_session")
+    @mock.patch("timesketch.lib.tasks.plaso")
+    @mock.patch("timesketch.lib.tasks.subprocess.check_output")
+    @mock.patch("timesketch.lib.tasks.OpenSearchDataStore")
+    @mock.patch("timesketch.lib.tasks.SearchIndex")
+    @mock.patch("timesketch.lib.tasks._set_datasource_status")
+    @mock.patch("timesketch.lib.tasks._set_datasource_total_events")
+    def test_run_plaso_without_filter(
+        self,
+        mock_set_total_events,
+        mock_set_status,
+        mock_search_index,
+        mock_datastore,
+        mock_subprocess,
+        mock_plaso,
+        mock_db_session,
+    ):
+        """Test run_plaso task without a filter."""
+        # Setup mocks
+        mock_plaso.__version__ = "20220101"
+
+        # Configure pinfo_tool mock
+        mock_pinfo_instance = tasks.pinfo_tool.PinfoTool.return_value
+        mock_storage_reader = mock.Mock()
+        mock_pinfo_instance._GetStorageReader.return_value = mock_storage_reader
+        mock_pinfo_instance._CalculateStorageCounters.return_value = {
+            "parsers": {"total": 100}
+        }
+
+        # Configure SearchIndex mock
+        mock_index_obj = mock.MagicMock()
+        mock_search_index.query.filter_by.return_value.first.return_value = mock_index_obj
+
+        # Configure OpenSearchDataStore mock
+        mock_datastore_instance = mock_datastore.return_value
+        mock_datastore_instance.client.indices.exists.return_value = True
+        mock_datastore_instance.create_index.return_value = "test_index"
+
+        mock_connection = mock.Mock()
+        mock_connection.host = "http://localhost:9200"
+        mock_connection.port = 9200
+        mock_datastore_instance.client.transport.get_connection.return_value = mock_connection
+
+        # Run the task
+        tasks.run_plaso(
+            file_path="/tmp/test.plaso",
+            events="",
+            timeline_name="test_timeline",
+            index_name="test_index",
+            source_type="plaso",
+            timeline_id=1,
+        )
+
+        # Verify that subprocess was called without the filter
+        self.assertTrue(mock_subprocess.called, "subprocess.check_output was not called")
+        args, _ = mock_subprocess.call_args
+        cmd_list = args[0]
+
+        self.assertNotIn("parser:syslog", cmd_list)


### PR DESCRIPTION
Implemented support for Plaso event filters in the import client and backend.
Users can now set a filter string using `streamer.set_plaso_event_filter('...')` which will be passed to `psort.py` during processing.


---
*PR created automatically by Jules for task [17610774320078571472](https://jules.google.com/task/17610774320078571472) started by @jkppr*