### PR TITLE
Update Pylint to 4.0.4 and fix configuration

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -140,9 +140,6 @@ recursive=yes
 # source root.
 source-roots=
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
 
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
@@ -486,6 +483,7 @@ disable=assignment-from-none,
         useless-object-inheritance,
         useless-suppression,
         consider-using-f-string,
+        too-many-positional-arguments,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/pylint_output.txt
+++ b/pylint_output.txt
@@ -1,6 +1,0 @@
-************* Module timesketch.api.v1.resources.event
-timesketch/api/v1/resources/event.py:934:15: E0606: Possibly using variable 'hits' before assignment (possibly-used-before-assignment)
-************* Module timesketch.lib.analyzers.yetiindicators
-timesketch/lib/analyzers/yetiindicators.py:150:12: E0606: Possibly using variable 'tags' before assignment (possibly-used-before-assignment)
-timesketch/lib/analyzers/yetiindicators.py:158:12: E0602: Undefined variable 'msg' (undefined-variable)
-timesketch/lib/analyzers/yetiindicators.py:206:29: E0606: Possibly using variable 'uri' before assignment (possibly-used-before-assignment)

--- a/pylint_output.txt
+++ b/pylint_output.txt
@@ -1,0 +1,6 @@
+************* Module timesketch.api.v1.resources.event
+timesketch/api/v1/resources/event.py:934:15: E0606: Possibly using variable 'hits' before assignment (possibly-used-before-assignment)
+************* Module timesketch.lib.analyzers.yetiindicators
+timesketch/lib/analyzers/yetiindicators.py:150:12: E0606: Possibly using variable 'tags' before assignment (possibly-used-before-assignment)
+timesketch/lib/analyzers/yetiindicators.py:158:12: E0602: Undefined variable 'msg' (undefined-variable)
+timesketch/lib/analyzers/yetiindicators.py:206:29: E0606: Possibly using variable 'uri' before assignment (possibly-used-before-assignment)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,6 +5,5 @@ pbr >= 4.2.0
 beautifulsoup4 >= 4.8.2
 coverage >= 5.0.2
 httmock >= 1.3.0
-pylint==2.17.7
-astroid==2.15.8
+pylint==4.0.4
 pytest-xdist>=3.6.1

--- a/timesketch/api/v1/resources/event.py
+++ b/timesketch/api/v1/resources/event.py
@@ -928,6 +928,7 @@ class EventAnnotationResource(resources.ResourceMixin, Resource):
                 HTTP_STATUS_CODE_INTERNAL_SERVER_ERROR,
                 f"Error while searching for event [{event_id}] to determine its index.",
             )
+        hits = []
         if isinstance(result, dict):
             hits = result.get("hits", {}).get("hits", [])
 

--- a/timesketch/lib/analyzers/yetiindicators.py
+++ b/timesketch/lib/analyzers/yetiindicators.py
@@ -140,6 +140,8 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
             event: a Timesketch sketch Event object.
             neighbors: a list of Yeti entities related to the indicator.
         """
+        tags = set()
+        msg = ""
         if indicator["root_type"] == "indicator":
             tags = {slugify(tag) for tag in indicator["relevant_tags"]}
             msg = f'Indicator match: "{indicator["name"]}" (ID: {indicator["id"]})\n'
@@ -179,6 +181,7 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
         """
         intel_type = "other"
         match_in_sketch = None
+        uri = ""
 
         if indicator["type"] == "regex":
             if "compiled_regexp" not in indicator:


### PR DESCRIPTION
Updated `pylint` to version 4.0.4 to resolve crash on Python 3.12.
- Updated `test_requirements.txt` to remove `astroid` pin (let `pylint` handle it) and set `pylint==4.0.4`.
- Updated `.pylintrc`:
  - Removed `suggestion-mode=yes` (removed in pylint 3.0).
  - Added `too-many-positional-arguments` to `disable` list (new check in pylint 3.2).
- Fixed 3 code issues reported by `pylint`:
  - `timesketch/api/v1/resources/event.py`: Initialized `hits` to avoid `E0606`.
  - `timesketch/lib/analyzers/yetiindicators.py`: Initialized `tags`, `msg`, and `uri` to avoid `E0606` and `E0602`.

---
*PR created automatically by Jules for task [11147361248291818084](https://jules.google.com/task/11147361248291818084) started by @jkppr*