### PR TITLE
Update documentation for Plaso event filtering

### DIFF
--- a/docs/developers/api-upload-data.md
+++ b/docs/developers/api-upload-data.md
@@ -200,6 +200,9 @@ with importer.ImportStreamer() as streamer:
   streamer.set_timeline_name('my_file_with_a_timeline')
   streamer.set_timestamp_description('some_description')
 
+  # Optional: Filter Plaso events
+  streamer.set_plaso_event_filter('data_type is "fs:stat"')
+
   streamer.add_file('/path_to_file/mydump.plaso')
 ```
 

--- a/docs/guides/user/upload-data.md
+++ b/docs/guides/user/upload-data.md
@@ -61,6 +61,10 @@ Other parameters suggested to be set are `sketch_id` (if it isn't provided a
 new sketch will be created) and `timeline_name` (otherwise a default name
 will be chosen).
 
+Additionally, for Plaso files, you can filter events during import using the
+`--plaso-event-filter` option, providing a standard Plaso filter string
+(e.g., `'data_type is "fs:stat"'`).
+
 For larger files the importer will split them up into pieces before uploading.
 
 ## Using the Web UI


### PR DESCRIPTION
Updated documentation to include the new Plaso event filtering options for both the CLI importer tool and the Python importer library. This allows users to filter events during import using standard Plaso filters.

---
*PR created automatically by Jules for task [5005904871769669903](https://jules.google.com/task/5005904871769669903) started by @jkppr*