### PR TITLE
Fix connection leak

### DIFF
--- a/timesketch/app.py
+++ b/timesketch/app.py
@@ -34,6 +34,7 @@ from timesketch.api.v1.routes import API_ROUTES as V1_API_ROUTES
 from timesketch.lib.errors import ApiHTTPError
 from timesketch.models import configure_engine
 from timesketch.models import init_db
+from timesketch.models import db_session
 from timesketch.models.user import User
 from timesketch.views.auth import auth_views
 from timesketch.views.spa import spa_views
@@ -210,6 +211,11 @@ def create_app(
 
     # Setup CSRF protection for the whole application
     CSRFProtect(app)
+
+    @app.teardown_appcontext
+    def shutdown_session(exception=None):
+        """Remove the database session after every request or app shutdown."""
+        db_session.remove()
 
     if app.config.get("ENABLE_PROFILING", False) and not app.config.get("TESTING"):
         # pylint: disable=import-outside-toplevel

--- a/timesketch/app_test.py
+++ b/timesketch/app_test.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the main application entry point."""
+
+from unittest.mock import patch
+from timesketch.app import create_app
+from timesketch.lib.testlib import BaseTest
+from timesketch.lib.testlib import TestConfig
+
+
+class AppTest(BaseTest):
+    """Test the main Flask app creation logic."""
+
+    @patch("timesketch.app.db_session")
+    def test_database_session_teardown(self, mock_db_session):
+        """Test that the database session is removed on app context teardown."""
+        app = create_app(config=TestConfig)
+
+        # 1. Verify shutdown_session is registered
+        teardown_funcs = app.teardown_appcontext_funcs
+        shutdown_func = next(
+            (func for func in teardown_funcs if func.__name__ == "shutdown_session"),
+            None,
+        )
+        self.assertIsNotNone(
+            shutdown_func, "shutdown_session not registered in teardown_appcontext"
+        )
+
+        # 2. Verify db_session.remove() is called when context exits
+        with app.app_context():
+            pass  # Just enter and exit the context
+
+        # Assert that remove() was called exactly once
+        mock_db_session.remove.assert_called_once()

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -179,17 +179,6 @@ def get_import_errors(error_container: dict, index_name: str, total_count: int):
     ).format(total_count - error_count, total_count, top_type, top_details)
 
 
-class SqlAlchemyTask(celery.Task):
-    """An abstract task that runs on task completion."""
-
-    abstract = True
-
-    def after_return(self, *args, **kwargs):
-        """Close the database session on task completion."""
-        db_session.remove()
-        super().after_return(*args, **kwargs)
-
-
 # pylint: disable=unused-argument
 @signals.worker_process_init.connect
 def init_worker(**kwargs):
@@ -781,7 +770,7 @@ def run_sketch_analyzer(
     return index_name
 
 
-@celery.task(track_started=True, base=SqlAlchemyTask)
+@celery.task(track_started=True)
 def run_plaso(
     file_path: str,
     events: str,
@@ -1069,7 +1058,7 @@ def run_plaso(
     return index_name
 
 
-@celery.task(track_started=True, base=SqlAlchemyTask)
+@celery.task(track_started=True)
 def run_csv_jsonl(
     file_path: str,
     events: str,

--- a/timesketch/wsgi.py
+++ b/timesketch/wsgi.py
@@ -61,12 +61,3 @@ if os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
     GunicornPrometheusMetrics(application, group_by="endpoint")
 
 
-@application.teardown_appcontext
-def shutdown_session(_exception=None):
-    """Remove the database session after every request or app shutdown.
-
-    Args:
-        _exception: An exception that occurred during the request, if any.
-                    (Unused, but required by the Flask teardown signal).
-    """
-    db_session.remove()


### PR DESCRIPTION
Register `db_session.remove()` in `create_app`'s `teardown_appcontext` to ensure cleanup after every request and task. Remove redundant cleanup in `wsgi.py` and `tasks.py`.

---
*PR created automatically by Jules for task [6144871847901439987](https://jules.google.com/task/6144871847901439987) started by @jkppr*