### PR TITLE
Relax OAuth scope validation to allow supersets

### DIFF
--- a/timesketch/views/auth.py
+++ b/timesketch/views/auth.py
@@ -286,7 +286,7 @@ def validate_api_token():
         )
 
     read_scopes = bearer_token_json.get("scope", "").split()
-    if not set(read_scopes) == set(SCOPES):
+    if not set(SCOPES).issubset(set(read_scopes)):
         return abort(
             HTTP_STATUS_CODE_UNAUTHORIZED,
             "Client scopes differ from what they should be (email, openid, "

--- a/timesketch/views/auth_test.py
+++ b/timesketch/views/auth_test.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 """Tests for the auth views."""
 
+from unittest import mock
 from flask import current_app
 from flask_login import current_user
 
 from timesketch.lib.definitions import HTTP_STATUS_CODE_REDIRECT
+from timesketch.lib.definitions import HTTP_STATUS_CODE_OK
 from timesketch.lib.testlib import BaseTest
 
 
@@ -58,3 +60,57 @@ class AuthViewTest(BaseTest):
         self.login()
         response = self.client.get("/logout/")
         self.assertEqual(response.status_code, HTTP_STATUS_CODE_REDIRECT)
+
+
+class AuthApiViewTest(BaseTest):
+    """Test the auth API view."""
+
+    @mock.patch("timesketch.views.auth.requests.post")
+    @mock.patch("timesketch.views.auth.get_oauth2_discovery_document")
+    @mock.patch("timesketch.views.auth.validate_jwt")
+    def test_validate_api_token_scope_superset(self, mock_validate_jwt, mock_discovery, mock_post):
+        """Test validate_api_token with superset of scopes."""
+        # Setup config
+        self.app.config["GOOGLE_OIDC_CLIENT_ID"] = "test_client_id"
+        self.app.config["GOOGLE_OIDC_API_CLIENT_ID"] = "test_api_client_id"
+
+        # Mock responses
+        mock_discovery.return_value = {"issuer": "https://accounts.google.com"}
+
+        # Mock requests.post
+        def side_effect(*args, **kwargs):
+            data = kwargs.get("data", {})
+            if "access_token" in data:
+                return mock.Mock(
+                    status_code=200,
+                    json=lambda: {
+                        # This includes extra scopes (short forms) causing the failure previously
+                        "scope": "email profile openid https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email",
+                        "azp": "test_client_id",
+                        "email": "test@example.com"
+                    }
+                )
+            if "id_token" in data:
+                 return mock.Mock(
+                    status_code=200,
+                    json=lambda: {
+                        "email_verified": True,
+                        "azp": "test_client_id",
+                        "email": "test@example.com",
+                        "aud": "test_client_id"
+                    }
+                )
+            return mock.Mock(status_code=400)
+
+        mock_post.side_effect = side_effect
+
+        # Headers and Args
+        headers = {
+            "Authorization": "Bearer test_access_token"
+        }
+
+        response = self.client.get("/login/api_callback/?id_token=test_id_token", headers=headers)
+
+        # We expect 200 because scope mismatch is now relaxed
+        self.assertEqual(response.status_code, HTTP_STATUS_CODE_OK)
+        self.assertIn(b"Authenticated", response.data)


### PR DESCRIPTION
Relax OAuth scope validation to allow supersets. The validation logic in `timesketch/views/auth.py` previously required an exact match between the expected scopes and the scopes returned by the token. This caused failures when the identity provider (e.g., Google) returned additional scopes or aliases. This change relaxes the check to ensure that the expected scopes are a *subset* of the returned scopes. Also added `AuthApiViewTest` in `timesketch/views/auth_test.py` to cover this scenario and prevent regression.

---
*PR created automatically by Jules for task [15277565582078078960](https://jules.google.com/task/15277565582078078960) started by @jkppr*