### PR TITLE
Enable sketch-level analyzers to run once per sketch

### DIFF
--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -861,6 +861,7 @@ class BaseAnalyzer:
     DISPLAY_NAME = None
     DESCRIPTION = None
     IS_DFIQ_ANALYZER = False
+    DEPENDS_ON_TIMELINE = True
 
     # If this analyzer depends on another analyzer
     # it needs to be included in this frozenset by using
@@ -1288,7 +1289,7 @@ class AnalyzerOutput:
                     "properties": {
                         "timesketch_instance": {"type": "string", "minLength": 1},
                         "sketch_id": {"type": "integer"},
-                        "timeline_id": {"type": "integer"},
+                        "timeline_id": {"type": ["integer", "null"]},
                         "saved_views": {
                             "type": "array",
                             "items": [

--- a/timesketch/lib/analyzers/interface_test.py
+++ b/timesketch/lib/analyzers/interface_test.py
@@ -91,3 +91,53 @@ class TestAnalysisSketch(BaseTest):
         self.assertIsInstance(indices, list)
         self.assertEqual(len(indices), 1)
         self.assertEqual(indices[0], "test")
+
+
+class TestAnalyzerOutput(BaseTest):
+    """Tests for the functionality of the AnalyzerOutput class."""
+
+    def test_analyzer_output_timeline_id_none(self):
+        """Test AnalyzerOutput with timeline_id=None."""
+        analyzer_output = interface.AnalyzerOutput(
+            analyzer_identifier="test_analyzer",
+            analyzer_name="Test Analyzer",
+            timesketch_instance="https://localhost",
+            sketch_id=1,
+            timeline_id=None,
+        )
+
+        analyzer_output.result_status = "SUCCESS"
+        analyzer_output.result_summary = "Test summary"
+
+        # This should not raise Validation Error
+        try:
+            json_output = analyzer_output.to_json()
+            self.assertIsNone(json_output["platform_meta_data"]["timeline_id"])
+
+            # Verify validation passes
+            analyzer_output.validate()
+        except Exception as e:
+            self.fail(f"AnalyzerOutput validation failed with timeline_id=None: {e}")
+
+    def test_analyzer_output_timeline_id_int(self):
+        """Test AnalyzerOutput with timeline_id as int."""
+        analyzer_output = interface.AnalyzerOutput(
+            analyzer_identifier="test_analyzer",
+            analyzer_name="Test Analyzer",
+            timesketch_instance="https://localhost",
+            sketch_id=1,
+            timeline_id=123,
+        )
+
+        analyzer_output.result_status = "SUCCESS"
+        analyzer_output.result_summary = "Test summary"
+
+        # This should not raise Validation Error
+        try:
+            json_output = analyzer_output.to_json()
+            self.assertEqual(json_output["platform_meta_data"]["timeline_id"], 123)
+
+            # Verify validation passes
+            analyzer_output.validate()
+        except Exception as e:
+            self.fail(f"AnalyzerOutput validation failed with timeline_id=123: {e}")

--- a/timesketch/lib/analyzers/llm_log_analyzer.py
+++ b/timesketch/lib/analyzers/llm_log_analyzer.py
@@ -34,6 +34,7 @@ class LLMLogAnalyzer(interface.BaseAnalyzer):
         "before it can be used!"
     )
     IS_DFIQ_ANALYZER = False
+    DEPENDS_ON_TIMELINE = False
 
     # The LLM Log analyzer will be triggered once per sketch, not per timeline.
     # The `timeline_id` will be None, and the analyzer should operate on all

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -583,10 +583,21 @@ def build_sketch_analysis_pipeline(
         if timeline_id:
             timeline = Timeline.get_by_id(timeline_id)
 
-        if not timeline:
+        # Check if the analyzer depends on a timeline or if it should be run
+        # on the sketch level.
+        is_sketch_analyzer = getattr(
+            analyzer_class, "DEPENDS_ON_TIMELINE", True
+        ) is False
+
+        if not timeline and not is_sketch_analyzer:
             timeline = Timeline.query.filter_by(
                 sketch=sketch, searchindex=searchindex
             ).first()
+
+        # If the analyzer is a sketch level analyzer we force the timeline
+        # to be None.
+        if is_sketch_analyzer:
+            timeline = None
 
         additional_kwargs = analyzer_class.get_kwargs()
         if isinstance(additional_kwargs, dict):
@@ -608,18 +619,38 @@ def build_sketch_analysis_pipeline(
 
         if not analyzer_force_run:
             skip_analysis = False
-            for past_analysis in timeline.analysis:
-                if (
-                    (past_analysis.analyzer_name == analyzer_name)
-                    and (past_analysis.get_status.status == "DONE")
-                    and (past_analysis.created_at > timeline.updated_at)
-                ):
-                    for attribute in past_analysis.get_attributes:
-                        if attribute.value == kwargs_list_hash:
-                            skip_analysis = True
-                            break
-                    if skip_analysis:
+            # Check if there is already an analysis running for this sketch
+            # for this analyzer.
+            if is_sketch_analyzer:
+                sketch_analyses = Analysis.query.filter_by(
+                    sketch=sketch, analyzer_name=analyzer_name
+                ).all()
+                for analysis in sketch_analyses:
+                    status = analysis.get_status.status
+                    if status in ("PENDING", "STARTED"):
+                        logger.info(
+                            "Analyzer %s is already running for sketch %d",
+                            analyzer_name,
+                            sketch_id,
+                        )
+                        skip_analysis = True
                         break
+
+            # If not a sketch analyzer, check if the analysis has already run
+            # on the timeline.
+            elif timeline:
+                for past_analysis in timeline.analysis:
+                    if (
+                        (past_analysis.analyzer_name == analyzer_name)
+                        and (past_analysis.get_status.status == "DONE")
+                        and (past_analysis.created_at > timeline.updated_at)
+                    ):
+                        for attribute in past_analysis.get_attributes:
+                            if attribute.value == kwargs_list_hash:
+                                skip_analysis = True
+                                break
+                        if skip_analysis:
+                            break
 
             if skip_analysis:
                 continue
@@ -640,6 +671,11 @@ def build_sketch_analysis_pipeline(
             db_session.add(analysis)
             analysis_session.analyses.append(analysis)
             db_session.commit()
+
+            # If the analyzer is a sketch analyzer we set the timeline_id to None
+            # to make sure it runs on the sketch level.
+            if is_sketch_analyzer:
+                timeline_id = None
 
             tasks.append(
                 run_sketch_analyzer.s(


### PR DESCRIPTION
Implemented sketch-level analyzer execution logic to prevent redundant runs of `LLMLogAnalyzer`.

*   Modified `timesketch/lib/analyzers/interface.py`:
    *   Added `DEPENDS_ON_TIMELINE = True` to `BaseAnalyzer`.
    *   Updated `AnalyzerOutput` schema to allow `null` for `timeline_id`.
*   Modified `timesketch/lib/analyzers/llm_log_analyzer.py`:
    *   Set `DEPENDS_ON_TIMELINE = False`.
*   Modified `timesketch/lib/tasks.py`:
    *   Updated `build_sketch_analysis_pipeline` to handle `is_sketch_analyzer`.
    *   Added de-duplication logic: checks for existing `PENDING` or `STARTED` analysis for the sketch/analyzer combination and skips scheduling if found.
    *   Forces `timeline_id=None` for sketch-level analyzers.
*   Added unit test in `timesketch/lib/analyzers/interface_test.py` to verify `AnalyzerOutput` accepts `timeline_id=None`.

---
*PR created automatically by Jules for task [14987996963004962857](https://jules.google.com/task/14987996963004962857) started by @jkppr*