### PR TITLE
Fix ACL validation for index parameter on event modification endpoints

### DIFF
--- a/timesketch/api/v1/resources/event.py
+++ b/timesketch/api/v1/resources/event.py
@@ -460,7 +460,23 @@ class EventAddAttributeResource(resources.ResourceMixin, Resource):
         events_by_index = self._parse_request(request)
         info_dict["chunks_per_index"] = {index: [] for index in list(events_by_index)}
 
+        allowed_statuses = ["ready"]
+        if current_app.config.get("SEARCH_PROCESSING_TIMELINES", False):
+            allowed_statuses.append("processing")
+
+        indices = [
+            t.searchindex.index_name
+            for t in sketch.timelines
+            if t.get_status.status.lower() in allowed_statuses
+        ]
+
         for index, events in events_by_index.items():
+            if index not in indices:
+                abort(
+                    HTTP_STATUS_CODE_FORBIDDEN,
+                    f"Search index ID ({index!s}) does not belong to the sketch",
+                )
+
             chunks = []
             for i in range(0, len(events), self.EVENT_CHUNK_SIZE):
                 chunks.append(events[i : i + self.EVENT_CHUNK_SIZE])
@@ -647,7 +663,23 @@ class EventTaggingResource(resources.ResourceMixin, Resource):
             tag_dict["number_of_indices"] = len(event_df["_index"].unique())
             time_tag_gathering_start = time.time()
 
+        allowed_statuses = ["ready"]
+        if current_app.config.get("SEARCH_PROCESSING_TIMELINES", False):
+            allowed_statuses.append("processing")
+
+        indices = [
+            t.searchindex.index_name
+            for t in sketch.timelines
+            if t.get_status.status.lower() in allowed_statuses
+        ]
+
         for _index in event_df["_index"].unique():
+            if _index not in indices:
+                abort(
+                    HTTP_STATUS_CODE_FORBIDDEN,
+                    f"Search index ID ({_index!s}) does not belong to the sketch",
+                )
+
             index_slice = event_df[event_df["_index"] == _index]
             index_size = index_slice.shape[0]
 
@@ -1549,6 +1581,16 @@ class EventUnTagResource(resources.ResourceMixin, Resource):
 
         datastore = self.datastore
 
+        allowed_statuses = ["ready"]
+        if current_app.config.get("SEARCH_PROCESSING_TIMELINES", False):
+            allowed_statuses.append("processing")
+
+        indices = [
+            t.searchindex.index_name
+            for t in sketch.timelines
+            if t.get_status.status.lower() in allowed_statuses
+        ]
+
         for _event in events:
             # every event entry can have a dedicated searchindex_id or searchindex_name
             searchindex_id = _event.get("searchindex_id", None)
@@ -1579,6 +1621,12 @@ class EventUnTagResource(resources.ResourceMixin, Resource):
                 abort(
                     HTTP_STATUS_CODE_BAD_REQUEST,
                     "Unable to query event on a closed search index.",
+                )
+
+            if searchindex.index_name not in indices:
+                abort(
+                    HTTP_STATUS_CODE_FORBIDDEN,
+                    f"Search index ID ({searchindex.index_name!s}) does not belong to the sketch",
                 )
 
             result = self.datastore.get_event(searchindex.index_name, _event.get("_id"))

--- a/timesketch/api/v1/resources_test.py
+++ b/timesketch/api/v1/resources_test.py
@@ -840,13 +840,13 @@ class EventAddAttributeResourceTest(BaseTest):
                 {
                     "_id": "1",
                     "_type": "_doc",
-                    "_index": "1",
+                    "_index": self.searchindex.index_name,
                     "attributes": attrs,
                 },
                 {
                     "_id": "2",
                     "_type": "_doc",
-                    "_index": "1",
+                    "_index": self.searchindex.index_name,
                     "attributes": attrs,
                 },
             ]
@@ -855,7 +855,7 @@ class EventAddAttributeResourceTest(BaseTest):
         expected_response = {
             "meta": {
                 "attributes_added": 2,
-                "chunks_per_index": {"1": 1},
+                "chunks_per_index": {self.searchindex.index_name: 1},
                 "error_count": 0,
                 "last_10_errors": [],
                 "events_modified": 2,
@@ -988,14 +988,14 @@ class EventAddAttributeResourceTest(BaseTest):
                     {
                         "_id": "1",
                         "_type": "_doc",
-                        "_index": "1",
+                        "_index": self.searchindex.index_name,
                         "attributes": attrs,
                     }
                 ]
                 * 1000
             },
         )
-        self.assertEqual({"1": 1}, response.json["meta"]["chunks_per_index"])
+        self.assertEqual({self.searchindex.index_name: 1}, response.json["meta"]["chunks_per_index"])
 
         # Two chunks when event count is chunk size + 1.
         response = self.client.post(
@@ -1005,16 +1005,23 @@ class EventAddAttributeResourceTest(BaseTest):
                     {
                         "_id": "1",
                         "_type": "_doc",
-                        "_index": "1",
+                        "_index": self.searchindex.index_name,
                         "attributes": attrs,
                     }
                 ]
                 * 1001
             },
         )
-        self.assertEqual({"1": 2}, response.json["meta"]["chunks_per_index"])
+        self.assertEqual({self.searchindex.index_name: 2}, response.json["meta"]["chunks_per_index"])
 
         # Chunk per index with multiple indexes.
+        self.timeline2 = self._create_timeline(
+            name="Timeline 2",
+            sketch=self.sketch1,
+            searchindex=self.searchindex2,
+            user=self.user1,
+        )
+
         response = self.client.post(
             self.resource_url,
             json={
@@ -1022,19 +1029,19 @@ class EventAddAttributeResourceTest(BaseTest):
                     {
                         "_id": "1",
                         "_type": "_doc",
-                        "_index": "1",
+                        "_index": self.searchindex.index_name,
                         "attributes": attrs,
                     },
                     {
                         "_id": "1",
                         "_type": "_doc",
-                        "_index": "2",
+                        "_index": self.searchindex2.index_name,
                         "attributes": attrs,
                     },
                 ]
             },
         )
-        self.assertEqual({"1": 1, "2": 1}, response.json["meta"]["chunks_per_index"])
+        self.assertEqual({self.searchindex.index_name: 1, self.searchindex2.index_name: 1}, response.json["meta"]["chunks_per_index"])
 
     @mock.patch("timesketch.api.v1.resources.OpenSearchDataStore", MockDataStore)
     def test_add_existing_attributes(self):
@@ -1048,7 +1055,7 @@ class EventAddAttributeResourceTest(BaseTest):
                     {
                         "_id": "1",
                         "_type": "_doc",
-                        "_index": "1",
+                        "_index": self.searchindex.index_name,
                         "attributes": [{"attr_name": "exists", "attr_value": "yes"}],
                     }
                 ]
@@ -1071,7 +1078,7 @@ class EventAddAttributeResourceTest(BaseTest):
                     {
                         "_id": "1",
                         "_type": "_doc",
-                        "_index": "1",
+                        "_index": self.searchindex.index_name,
                         "attributes": [{"attr_name": "_invalid", "attr_value": "yes"}],
                     }
                 ]
@@ -1094,7 +1101,7 @@ class EventAddAttributeResourceTest(BaseTest):
                     {
                         "_id": "1",
                         "_type": "_doc",
-                        "_index": "1",
+                        "_index": self.searchindex.index_name,
                         "attributes": [{"attr_name": "message", "attr_value": "yes"}],
                     }
                 ]


### PR DESCRIPTION
This PR fixes an ACL bypassing vulnerability in the Timesketch event modification API endpoints. Prior to this fix, users could modify events, tags, and attributes on timelines they did not have access to by simply injecting the target timeline's index into the `_index` payload of endpoints belonging to their own sketch.

Affected endpoints:
- `EventUnTagResource.post()`
- `EventTaggingResource.post()`
- `EventAddAttributeResource.post()`

The fix resolves the issue by securely validating the provided index values against the set of timeline indices that actually belong to the targeted sketch. The index is considered valid only if the corresponding timeline has a status of "ready" (or optionally "processing", if configured). If the validation fails, a `403 Forbidden` response is returned.

Relevant tests were updated to ensure accurate matching of mock search indices.

---
*PR created automatically by Jules for task [858097040093559869](https://jules.google.com/task/858097040093559869) started by @jkppr*