### PR TITLE
URL-encode query parameters in Event URL copies

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/EventActionMenu.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventActionMenu.vue
@@ -99,7 +99,7 @@ export default {
     },
     copyEventUrlToClipboard() {
       try {
-        let eventUrl = window.location.origin + this.$route.path + '?q=_id:"' + this.event._id + '"'
+        let eventUrl = window.location.origin + this.$route.path + '?q=' + encodeURIComponent('_id:"' + this.event._id + '"')
         navigator.clipboard.writeText(eventUrl)
         this.infoSnackBar('Event URL copied to clipboard')
       } catch (error) {


### PR DESCRIPTION
Fixed a bug where event URLs were generated with raw characters, causing sharing issues. Added `encodeURIComponent` to the query payload.

---
*PR created automatically by Jules for task [11125748377383717985](https://jules.google.com/task/11125748377383717985) started by @jkppr*