### PR TITLE
Fix sketch list pagination total_items count inflation

### DIFF
--- a/timesketch/models/acl.py
+++ b/timesketch/models/acl.py
@@ -148,7 +148,7 @@ class AccessControlMixin:
             ),
             cls.AccessControlEntry.permission == "read",
             cls.AccessControlEntry.parent,
-        )
+        ).distinct()
 
     def _get_ace(
         self,


### PR DESCRIPTION
Fixes issue #3775 where the sketch list API endpoint (`GET /api/v1/sketches/`) reports an incorrect `total_items` count in its pagination metadata. This occurs when a user has multiple matching ACL entries for the same sketch (e.g., being in multiple groups with access). The fix is to append `.distinct()` to the SQLAlchemy query in `timesketch/models/acl.py` `AccessControlMixin.all_with_acl()` to ensure the database correctly dedupes the sketches prior to `count()` operations.

---
*PR created automatically by Jules for task [18239042637690130477](https://jules.google.com/task/18239042637690130477) started by @jkppr*