### PR TITLE
feat: Add jump to event button in context search

### DIFF
--- a/timesketch/frontend-ng/src/App.vue
+++ b/timesketch/frontend-ng/src/App.vue
@@ -44,7 +44,7 @@ export default {
   methods: {
     setErrorSnackBar: function (message) {
       const snackbar = {
-        message: message,
+        message,
         color: 'error',
         timeout: 7000,
       }
@@ -52,7 +52,7 @@ export default {
     },
     setWarningSnackBar: function (message) {
       const snackbar = {
-        message: message,
+        message,
         color: 'warning',
         timeout: 5000,
       }

--- a/timesketch/frontend-ng/src/components/Explore/AggregateDialog.vue
+++ b/timesketch/frontend-ng/src/components/Explore/AggregateDialog.vue
@@ -361,7 +361,7 @@ export default {
             show: true,
             hideOverlappingLabels: true
           },
-          categories: categories
+          categories
         },
       }
     },
@@ -403,7 +403,7 @@ export default {
       return [
         {
           name: 'Events by ' + this.selectedDistributionInterval,
-          data: data
+          data
         }
       ]
     },

--- a/timesketch/frontend-ng/src/components/Explore/BarChart.vue
+++ b/timesketch/frontend-ng/src/components/Explore/BarChart.vue
@@ -135,7 +135,7 @@ export default {
     },
     emitFilterRequest(config) {
       let dataPointIndex = config.selectedDataPoints[0][0]
-      let series = config.w.config.series[0]['data']
+      let series = config.w.config.series[0].data
 
       // Exit early if this is the last bucket.
       if (series.length === 1) {

--- a/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
@@ -275,8 +275,8 @@ export default {
     checkContextLinkDisplay(key, value) {
       const fieldConfList = this.contextLinkConf[key.toLowerCase()] ? this.contextLinkConf[key.toLowerCase()] : []
       for (const confItem of fieldConfList) {
-        if (confItem['validation_regex'] !== '' && confItem['validation_regex'] !== undefined) {
-          let validationPattern = confItem['validation_regex']
+        if (confItem.validation_regex !== '' && confItem.validation_regex !== undefined) {
+          let validationPattern = confItem.validation_regex
           let regexIdentifiers = validationPattern.slice(validationPattern.lastIndexOf('/') + 1)
           let regexPattern = validationPattern.slice(
             validationPattern.indexOf('/') + 1,
@@ -297,29 +297,29 @@ export default {
     contextLinkRedirect(key, item, value) {
       const fieldConfList = this.contextLinkConf[key.toLowerCase()] ? this.contextLinkConf[key.toLowerCase()] : []
       for (const confItem of fieldConfList) {
-        if (confItem['short_name'] === item) {
-          if (confItem['type'] === 'hardcoded_modules') {
-            if (confItem['module'] === 'xml_formatter') {
+        if (confItem.short_name === item) {
+          if (confItem.type === 'hardcoded_modules') {
+            if (confItem.module === 'xml_formatter') {
               this.formatXMLString = true
               this.contextValue = value
               return
             }
-            if (confItem['module'] === 'unfurl_graph') {
+            if (confItem.module === 'unfurl_graph') {
               this.dfirUnfurlDialog = true
               this.contextValue = value
               return
             }
-            if (confItem['module'] === 'threat_intel') {
+            if (confItem.module === 'threat_intel') {
               EventBus.$emit('addIndicator', value)
               return
             }
           } else {
-            if (confItem['redirect_warning']) {
+            if (confItem.redirect_warning) {
               this.redirectWarnDialog = true
               this.contextValue = value
-              this.contextUrl = confItem['context_link'].replace('<ATTR_VALUE>', encodeURIComponent(value))
+              this.contextUrl = confItem.context_link.replace('<ATTR_VALUE>', encodeURIComponent(value))
             } else {
-              window.open(confItem['context_link'].replace('<ATTR_VALUE>', encodeURIComponent(value)), '_blank')
+              window.open(confItem.context_link.replace('<ATTR_VALUE>', encodeURIComponent(value)), '_blank')
               this.redirectWarnDialog = false
             }
           }
@@ -329,17 +329,17 @@ export default {
     getContextLinkType(key, item) {
       const fieldConfList = this.contextLinkConf[key.toLowerCase()] ? this.contextLinkConf[key.toLowerCase()] : []
       for (const confItem of fieldConfList) {
-        if (confItem['short_name'] === item) {
-          return confItem['type']
+        if (confItem.short_name === item) {
+          return confItem.type
         }
       }
     },
     getContextLinkRedirectState(key, item) {
       const fieldConfList = this.contextLinkConf[key.toLowerCase()] ? this.contextLinkConf[key.toLowerCase()] : []
       for (const confItem of fieldConfList) {
-        if (confItem['short_name'] === item) {
-          if (confItem['redirect_warning']) {
-            return confItem['redirect_warning']
+        if (confItem.short_name === item) {
+          if (confItem.redirect_warning) {
+            return confItem.redirect_warning
           } else {
             return false
           }
@@ -365,9 +365,9 @@ export default {
       eventData.doSearch = true
       let chip = {
         field: key,
-        value: value,
+        value,
         type: 'term',
-        operator: operator,
+        operator,
         active: true,
       }
       eventData.chip = chip

--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -814,9 +814,9 @@ export default {
 
       let orderAsc = this.currentQueryFilter.order === 'asc'
       if (orderAsc) {
-        jumpTimeChip.value = ',' + eventTimestampIso
+        jumpTimeChip.value = '1000-01-01T00:00:00.000Z,' + eventTimestampIso
       } else {
-        jumpTimeChip.value = eventTimestampIso + ','
+        jumpTimeChip.value = eventTimestampIso + ',9999-12-31T23:59:59.999Z'
       }
 
       if (!countQueryFilter.chips) {
@@ -900,11 +900,11 @@ export default {
       let index = this.expandedRows.findIndex((x) => x._id === row._id)
       if (this.expandedRows.some((event) => event._id === row._id)) {
         if (row.showDetails) {
-          row['showDetails'] = false
+          row.showDetails = false
           this.expandedRows.splice(index, 1)
           this.$set(row, 'showComments', false)
         } else {
-          row['showDetails'] = true
+          row.showDetails = true
           this.expandedRows.splice(index, 1)
           this.expandedRows.push(row)
           return
@@ -915,7 +915,7 @@ export default {
           this.expandedRows.push(row)
         }
       } else {
-        row['showDetails'] = true
+        row.showDetails = true
         this.expandedRows.push(row)
       }
     },
@@ -944,7 +944,7 @@ export default {
         }
         let deltaDays = Math.floor(delta / 60 / 60 / 24)
         if (deltaDays > 0) {
-          prevEvent['deltaDays'] = deltaDays
+          prevEvent.deltaDays = deltaDays
           this.expandedRows.push(prevEvent)
         }
       })
@@ -1037,11 +1037,11 @@ export default {
 
       // Search history
       if (incognito) {
-        formData['incognito'] = true
+        formData.incognito = true
       }
 
       if (parent) {
-        formData['parent'] = parent
+        formData.parent = parent
       }
 
       if (parent && incognito) {
@@ -1049,15 +1049,15 @@ export default {
       }
 
       if (this.branchParent) {
-        formData['parent'] = this.branchParent
+        formData.parent = this.branchParent
       }
 
       // Get DFIQ context
-      formData['scenario'] = this.activeContext.scenarioId
-      formData['facet'] = this.activeContext.facetId
-      formData['question'] = this.activeContext.questionId
+      formData.scenario = this.activeContext.scenarioId
+      formData.facet = this.activeContext.facetId
+      formData.question = this.activeContext.questionId
 
-      formData['include_processing_timelines'] = this.settings.showProcessingTimelineEvents
+      formData.include_processing_timelines = this.settings.showProcessingTimelineEvents
 
       ApiClient.search(this.sketch.id, formData)
         .then((response) => {
@@ -1331,9 +1331,9 @@ export default {
         this.currentQueryString = newQueryRequest.queryString || ''
         this.currentQueryFilter = newQueryRequest.queryFilter || defaultQueryFilter()
         this.currentQueryDsl = newQueryRequest.queryDsl || null
-        let resetPagination = newQueryRequest['resetPagination'] || false
-        let incognito = newQueryRequest['incognito'] || false
-        let parent = newQueryRequest['parent'] || false
+        let resetPagination = newQueryRequest.resetPagination || false
+        let incognito = newQueryRequest.incognito || false
+        let parent = newQueryRequest.parent || false
         // Set additional fields. This is used when loading filter from a saved search.
         if (this.currentQueryFilter.fields) {
           this.selectedFields = this.currentQueryFilter.fields

--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -102,12 +102,15 @@ limitations under the License.
 
     <div v-if="highlightEvent" class="mt-4">
       <strong>Showing context for event:</strong>
-      <v-sheet class="d-flex flex-wrap mt-1 mb-5">
+          <v-sheet class="d-flex flex-wrap mt-1 mb-5 align-center">
         <v-sheet class="flex-1-0">
           <span style="width: 200px" v-bind:style="getTimelineColor(highlightEvent)" class="datetime-table-cell pa-2">
             {{ highlightEvent._source.timestamp | formatTimestamp | toISO8601 }}
           </span>
         </v-sheet>
+            <v-btn icon title="Jump to this event" @click="jumpToHighlightedEvent" class="ml-2 mr-2">
+              <v-icon color="primary">mdi-crosshairs-gps</v-icon>
+            </v-btn>
 
         <v-sheet class="">
           <span class="datetime-table-cell pa-2">
@@ -526,6 +529,7 @@ limitations under the License.
 import ApiClient from '../../utils/RestApiClient.js'
 import EventBus from '../../event-bus.js'
 import EventMixin from '../../mixins/EventMixin'
+import dayjs from '@/plugins/dayjs'
 
 import TsBarChart from './BarChart.vue'
 import TsEventDetail from './EventDetail.vue'
@@ -793,6 +797,90 @@ export default {
     },
   },
   methods: {
+    jumpToHighlightedEvent() {
+      if (!this.highlightEvent) return
+
+      let countQueryFilter = JSON.parse(JSON.stringify(this.currentQueryFilter))
+      let eventTimestampMillis = this.$options.filters.formatTimestamp(this.highlightEvent._source.timestamp)
+      let eventTimestampIso = dayjs.utc(eventTimestampMillis).toISOString()
+
+      let jumpTimeChip = {
+        field: '',
+        value: '',
+        type: 'datetime_range',
+        operator: 'must',
+        active: true,
+      }
+
+      let orderAsc = this.currentQueryFilter.order === 'asc'
+      if (orderAsc) {
+        jumpTimeChip.value = ',' + eventTimestampIso
+      } else {
+        jumpTimeChip.value = eventTimestampIso + ','
+      }
+
+      if (!countQueryFilter.chips) {
+        countQueryFilter.chips = []
+      }
+      countQueryFilter.chips.push(jumpTimeChip)
+
+      let formData = {
+        filter: countQueryFilter,
+        query: this.currentQueryString || '*',
+        count: true
+      }
+
+      if (this.currentQueryDsl) {
+        formData.dsl = this.currentQueryDsl
+      }
+
+      ApiClient.search(this.sketch.id, formData)
+        .then((response) => {
+          let precedingCount = response.data.meta.total_count || 0
+
+          let pageTarget = Math.floor(precedingCount / this.tableOptions.itemsPerPage) + 1
+
+          if (this.tableOptions.page === pageTarget && !this.searchInProgress) {
+            this.scrollToHighlightedEvent()
+          } else {
+            this.tableOptions.page = pageTarget
+
+            let searchStarted = false
+            let checkInterval = setInterval(() => {
+              if (this.searchInProgress) {
+                searchStarted = true
+              }
+              if (searchStarted && !this.searchInProgress && this.eventList.objects.length > 0) {
+                clearInterval(checkInterval)
+                this.$nextTick(() => {
+                  this.scrollToHighlightedEvent()
+                })
+              }
+            }, 100)
+
+            setTimeout(() => clearInterval(checkInterval), 10000)
+          }
+        })
+        .catch((e) => {
+          this.errorSnackBar('Failed to calculate event position.')
+          console.error(e)
+        })
+    },
+    scrollToHighlightedEvent() {
+      let highlightEls = this.$el.querySelectorAll('.ts-event-field-highlight')
+      if (highlightEls && highlightEls.length > 0) {
+        let tr = highlightEls[0].closest('tr')
+        if (tr) {
+          tr.scrollIntoView({ behavior: 'smooth', block: 'center' })
+
+          tr.style.transition = 'background-color 0.5s ease'
+          tr.style.backgroundColor = 'rgba(255, 0, 0, 0.1)'
+          setTimeout(() => {
+            tr.style.backgroundColor = ''
+          }, 1500)
+        }
+      }
+    },
     toggleSummary() {
           this.summaryCollapsed = !this.summaryCollapsed;
           localStorage.setItem('aiSummaryCollapsed', String(this.summaryCollapsed));

--- a/timesketch/frontend-ng/src/components/Explore/EventTagDialog.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventTagDialog.vue
@@ -156,7 +156,7 @@ export default {
               event._source.tag.splice(index, 1)
             }
           }
-          this.$store.dispatch('updateTimelineTags', { sketchId: this.sketch.id, tag: tag, num: -1 })
+          this.$store.dispatch('updateTimelineTags', { sketchId: this.sketch.id, tag, num: -1 })
         })
         .catch((e) => {
           console.error(e)

--- a/timesketch/frontend-ng/src/components/Explore/SearchHistoryTree.vue
+++ b/timesketch/frontend-ng/src/components/Explore/SearchHistoryTree.vue
@@ -98,7 +98,7 @@ export default {
         .then((response) => {
           this.treeData = response.data.objects[0]
           if (!this.selectedNode) {
-            let lastNodeId = response.data.meta['last_node_id']
+            let lastNodeId = response.data.meta.last_node_id
             this.selectedNode = findSearchNode(this.treeData, 'id', (k, v) => v === lastNodeId)
           }
         })

--- a/timesketch/frontend-ng/src/components/Explore/TimelineComponent.vue
+++ b/timesketch/frontend-ng/src/components/Explore/TimelineComponent.vue
@@ -540,7 +540,7 @@ export default {
     } else {
       this.autoRefresh = false
       if (timelineStat) {
-        this.allIndexedEvents = timelineStat['count']
+        this.allIndexedEvents = timelineStat.count
       }
     }
     this.newTimelineName = this.timeline.name

--- a/timesketch/frontend-ng/src/components/Graph/Cytoscape.vue
+++ b/timesketch/frontend-ng/src/components/Graph/Cytoscape.vue
@@ -406,8 +406,8 @@ export default {
       }
       ApiClient.getSavedGraph(this.sketch.id, graphId)
         .then((response) => {
-          this.currentGraph = response.data['objects'][0].name
-          let elements = JSON.parse(response.data['objects'][0].graph_elements)
+          this.currentGraph = response.data.objects[0].name
+          let elements = JSON.parse(response.data.objects[0].graph_elements)
           let nodes = elements.filter((ele) => ele.group === 'nodes')
           let edges = elements.filter((ele) => ele.group === 'edges')
           let orderedElements = []
@@ -460,7 +460,7 @@ export default {
       }
       ApiClient.generateGraphFromPlugin(this.sketch.id, this.currentGraph, currentIndices, timelineIds, refresh)
         .then((response) => {
-          let graphCache = response.data['objects'][0]
+          let graphCache = response.data.objects[0]
           let elementsCache = JSON.parse(graphCache.graph_elements)
           let configCache = JSON.parse(graphCache.graph_config)
           let elements = []
@@ -468,11 +468,11 @@ export default {
           let edges
 
           if ('elements' in elementsCache) {
-            nodes = elementsCache['elements']['nodes']
-            edges = elementsCache['elements']['edges']
+            nodes = elementsCache.elements.nodes
+            edges = elementsCache.elements.edges
           } else {
-            nodes = elementsCache['nodes']
-            edges = elementsCache['edges']
+            nodes = elementsCache.nodes
+            edges = elementsCache.edges
           }
           nodes.forEach((node) => {
             elements.push({ data: node.data, group: 'nodes' })

--- a/timesketch/frontend-ng/src/components/LeftPanel/AnalyzerResultTimeline.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/AnalyzerResultTimeline.vue
@@ -336,35 +336,35 @@ export default {
       let metaData = {}
       if (this.verboseAnalyzerOutput !== undefined && this.verboseAnalyzerOutput.platform_meta_data !== undefined) {
         if (this.verboseAnalyzerOutput.platform_meta_data.saved_views !== undefined) {
-          metaData['Searches'] = []
+          metaData.Searches = []
           for (const id of this.verboseAnalyzerOutput.platform_meta_data.saved_views) {
             let view = this.meta.views.find((view) => view.id === id)
             if (view !== undefined) {
-              metaData['Searches'].push(view)
+              metaData.Searches.push(view)
             }
           }
         }
         if (this.verboseAnalyzerOutput.platform_meta_data.saved_stories !== undefined) {
-          metaData['Story'] = []
+          metaData.Story = []
           for (const id of this.verboseAnalyzerOutput.platform_meta_data.saved_stories) {
             let storie = this.meta.stories.find((storie) => storie.id === id)
             if (storie !== undefined) {
-              metaData['Story'].push(storie)
+              metaData.Story.push(storie)
             }
           }
         }
         if (this.verboseAnalyzerOutput.platform_meta_data.saved_graphs !== undefined) {
-          metaData['Graphs'] = []
+          metaData.Graphs = []
           for (const id of this.verboseAnalyzerOutput.platform_meta_data.saved_graphs) {
             if (typeof id === 'number') {
               let savedGraph = this.savedGraphs.find((graph) => graph.id === id)
               if (savedGraph !== undefined) {
-                metaData['Graphs'].push(savedGraph)
+                metaData.Graphs.push(savedGraph)
               }
             } else if (typeof id === 'string') {
               let pluginGraph = this.graphs.find((graph) => graph.name === id)
               if (pluginGraph !== undefined) {
-                metaData['Graphs'].push(pluginGraph)
+                metaData.Graphs.push(pluginGraph)
               }
             } else {
               console.error('Saved Graph reference is neither Integer nor String.', typeof id, id)
@@ -372,13 +372,13 @@ export default {
           }
         }
         if (this.verboseAnalyzerOutput.platform_meta_data.saved_aggregations !== undefined) {
-          metaData['Aggregations'] = this.verboseAnalyzerOutput.platform_meta_data.saved_aggregations
+          metaData.Aggregations = this.verboseAnalyzerOutput.platform_meta_data.saved_aggregations
         }
         if (this.verboseAnalyzerOutput.platform_meta_data.created_tags !== undefined) {
-          metaData['Tags'] = this.verboseAnalyzerOutput.platform_meta_data.created_tags
+          metaData.Tags = this.verboseAnalyzerOutput.platform_meta_data.created_tags
         }
         if (this.verboseAnalyzerOutput.platform_meta_data.created_attributes !== undefined) {
-          metaData['Attributes'] = this.verboseAnalyzerOutput.platform_meta_data.created_attributes
+          metaData.Attributes = this.verboseAnalyzerOutput.platform_meta_data.created_attributes
         }
         return metaData
       }

--- a/timesketch/frontend-ng/src/components/LeftPanel/AnalyzerResults.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/AnalyzerResults.vue
@@ -403,7 +403,7 @@ export default {
           const activeSessionsDetailed = response.data.objects[0].detailed_sessions
           if (activeSessionsDetailed.length > 0) {
             for (const session of activeSessionsDetailed) {
-              activeAnalyses.push(...session.objects[0]['analyses'])
+              activeAnalyses.push(...session.objects[0].analyses)
             }
           }
         }

--- a/timesketch/frontend-ng/src/components/LeftPanel/SigmaRule.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/SigmaRule.vue
@@ -249,7 +249,7 @@ export default {
       eventData.queryString = '*'
       let chip = {
         field: 'tag',
-        value: value,
+        value,
         type: 'term',
         operator: 'must',
         active: true,

--- a/timesketch/frontend-ng/src/components/LeftPanel/ThreatIntel.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/ThreatIntel.vue
@@ -251,9 +251,9 @@ export default {
         if (this.tagMetadata[tag]) {
           return _.extend(tagInfo, this.tagMetadata[tag])
         } else {
-          for (var regex in this.tagMetadata['regexes']) {
+          for (var regex in this.tagMetadata.regexes) {
             if (tag.match(regex)) {
-              return _.extend(tagInfo, this.tagMetadata['regexes'][regex])
+              return _.extend(tagInfo, this.tagMetadata.regexes[regex])
             }
           }
           return _.extend(tagInfo, this.tagMetadata.default)

--- a/timesketch/frontend-ng/src/components/LeftPanel/Visualizations.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/Visualizations.vue
@@ -245,7 +245,7 @@ export default {
         return []
       }
       return this.$store.state.savedVisualizations.filter(
-          (e) => JSON.parse(e.parameters)['aggregator_class'] === 'apex'
+          (e) => JSON.parse(e.parameters).aggregator_class === 'apex'
       )
     },
     visualizationCount() {
@@ -253,7 +253,7 @@ export default {
         return 0
       }
       return this.$store.state.savedVisualizations.filter(
-          (e) => JSON.parse(e.parameters)['aggregator_class'] === 'apex'
+          (e) => JSON.parse(e.parameters).aggregator_class === 'apex'
       ).length
     },
     sketch() {

--- a/timesketch/frontend-ng/src/components/Scenarios/QuestionCard.vue
+++ b/timesketch/frontend-ng/src/components/Scenarios/QuestionCard.vue
@@ -371,12 +371,12 @@ export default {
       }
       let matches = {}
       if (this.sketchQuestions) {
-        matches['questions'] = this.sketchQuestions.filter((question) =>
+        matches.questions = this.sketchQuestions.filter((question) =>
           question.name.toLowerCase().includes(this.queryString.toLowerCase())
         )
       }
       if (this.questionTemplates) {
-        matches['templates'] = this.questionTemplates.filter((template) =>
+        matches.templates = this.questionTemplates.filter((template) =>
           template.name.toLowerCase().includes(this.queryString.toLowerCase())
         )
       }

--- a/timesketch/frontend-ng/src/components/Sigma/SigmaEditor.vue
+++ b/timesketch/frontend-ng/src/components/Sigma/SigmaEditor.vue
@@ -84,7 +84,7 @@ export default {
       editingRule: {},
       status_text: '',
       ruleYamlTextArea: '',
-      SigmaTemplates: SigmaTemplates,
+      SigmaTemplates,
       search: '',
       isParsingSuccesful: false,
     }

--- a/timesketch/frontend-ng/src/components/ThreatIntel/IndicatorDialog.vue
+++ b/timesketch/frontend-ng/src/components/ThreatIntel/IndicatorDialog.vue
@@ -56,7 +56,7 @@ export default {
   props: ['dialog', 'tagInfo', 'index', 'ioc'],
   data() {
     return {
-      IOCTypes: IOCTypes,
+      IOCTypes,
       newIndicator: newIndicator(),
     }
   },

--- a/timesketch/frontend-ng/src/components/UploadForm.vue
+++ b/timesketch/frontend-ng/src/components/UploadForm.vue
@@ -341,7 +341,7 @@ export default {
             color = this.colors.find((x) => x.name === 'red').value
           }
         }
-        return { name: header, values: values, color: color }
+        return { name: header, values, color }
       })
     },
   },
@@ -362,9 +362,9 @@ export default {
       this.showAddColumnFlag = !this.showAddColumnFlag
     },
     getDefaultValue: function (target) {
-      let obj = this.headersMapping.find((x) => x['target'] === target)
+      let obj = this.headersMapping.find((x) => x.target === target)
       if (obj) {
-        return obj['default_value']
+        return obj.default_value
       } else {
         return null
       }
@@ -372,7 +372,7 @@ export default {
     changeCSVDelimiter: function (value) {
       this.CSVDelimiter = value
       for (let i = 0; i < this.mandatoryHeaders.length; i++) {
-        this.mandatoryHeaders[i]['columnsSelected'] = []
+        this.mandatoryHeaders[i].columnsSelected = []
       }
       this.headersMapping = []
       this.validateFile()
@@ -419,10 +419,10 @@ export default {
         sources = this.mandatoryHeaders[i].columnsSelected
       }
 
-      this.headersMapping = this.headersMapping.filter((mapping) => mapping['target'] !== target)
+      this.headersMapping = this.headersMapping.filter((mapping) => mapping.target !== target)
       if (sources === null || sources.length > 0)
         this.headersMapping.push({
-          target: target,
+          target,
           source: sources,
           default_value: defaultValue,
         })
@@ -443,7 +443,7 @@ export default {
       this.percentCompleted = 0
 
       for (let i = 0; i < this.mandatoryHeaders.length; i++) {
-        this.mandatoryHeaders[i]['columnsSelected'] = []
+        this.mandatoryHeaders[i].columnsSelected = []
       }
     },
     submitForm: function () {
@@ -495,7 +495,7 @@ export default {
           this.error.push('Missing headers: ' + this.missingHeaders.toString())
         }
         // 2. check for duplicate headers (except from the new header and multiple headers)
-        let duplicates = this.headersMapping.filter((mapping) => mapping['source']).map((e) => e.source)
+        let duplicates = this.headersMapping.filter((mapping) => mapping.source).map((e) => e.source)
         duplicates = duplicates.filter((x) => x.length === 1).map((x) => x[0]) // only mapping 1:1. They will be renamed on the database thus we do not want duplicates
         if (duplicates.length > new Set(duplicates).size) {
           this.error.push(`New headers mapping contains duplicates (${duplicates})`)

--- a/timesketch/frontend-ng/src/components/Visualization/AggregationEventSelect.vue
+++ b/timesketch/frontend-ng/src/components/Visualization/AggregationEventSelect.vue
@@ -125,7 +125,7 @@ export default {
         let recentSearches = this.$store.state.searchHistory.map(
           (view) => {
             return {
-              text: `${view['query_string']} (${view['query_result_count']})`,
+              text: `${view.query_string} (${view.query_result_count})`,
               value: view
             }
           }
@@ -138,7 +138,7 @@ export default {
       let savedSearches = this.$store.state.meta.views.map(
         (view) => {
           return {
-            text: view['name'], value: view
+            text: view.name, value: view
           }
         }
       )

--- a/timesketch/frontend-ng/src/components/Visualization/ChartTable.vue
+++ b/timesketch/frontend-ng/src/components/Visualization/ChartTable.vue
@@ -197,9 +197,9 @@ export default {
       eventData.doSearch = true
       let chip = {
         field: key,
-        value: value,
+        value,
         type: 'term',
-        operator: operator,
+        operator,
         active: true,
       }
       eventData.chip = chip

--- a/timesketch/frontend-ng/src/components/Visualization/EventFieldSelect.vue
+++ b/timesketch/frontend-ng/src/components/Visualization/EventFieldSelect.vue
@@ -68,13 +68,13 @@ export default {
         .filter(
           (mapping) => {
             return (
-              mapping['field'] !== 'datetime'
-              && mapping['field'] !== 'timestamp'
+              mapping.field !== 'datetime'
+              && mapping.field !== 'timestamp'
             )
         })
         .map(
           (mapping) => {
-            return {text: mapping['field'], value: mapping}}
+            return {text: mapping.field, value: mapping}}
         )
       return mappings
     },

--- a/timesketch/frontend-ng/src/components/Visualization/VisualizationEditor.vue
+++ b/timesketch/frontend-ng/src/components/Visualization/VisualizationEditor.vue
@@ -330,8 +330,8 @@ export default {
         return
       }
 
-      const queryFilter = JSON.parse(currentSearchNode['query_filter'])
-      this.selectedQueryString = currentSearchNode['query_string']
+      const queryFilter = JSON.parse(currentSearchNode.query_filter)
+      this.selectedQueryString = currentSearchNode.query_string
       this.selectedTimelineIDs = queryFilter.indices;
       this.selectedQueryChips = queryFilter.chips.filter(
         (chip) => chip.type === 'label' || chip.type === 'term' || chip.type === 'datetime_range'
@@ -343,8 +343,8 @@ export default {
         return
       }
 
-      const queryFilter = JSON.parse(this.selectedRecentSearch['query_filter'])
-      this.selectedQueryString = this.selectedRecentSearch['query_string']
+      const queryFilter = JSON.parse(this.selectedRecentSearch.query_filter)
+      this.selectedQueryString = this.selectedRecentSearch.query_string
       this.selectedTimelineIDs = queryFilter.indices;
       this.selectedQueryChips = queryFilter.chips.filter(
         (chip) => chip.type === 'label' || chip.type === 'term' || chip.type === 'datetime_range'

--- a/timesketch/frontend-ng/src/mixins/snackBar.js
+++ b/timesketch/frontend-ng/src/mixins/snackBar.js
@@ -18,33 +18,33 @@ Vue.mixin({
     methods: {
         successSnackBar(message, timeout = defaultTimeout) {
             const snackbar = {
-                message: message,
+                message,
                 color: "success",
-                timeout: timeout
+                timeout
             }
             this.$store.dispatch('setSnackBar', snackbar)
         },
         errorSnackBar(message, timeout = defaultTimeout) {
             const snackbar = {
-                message: message,
+                message,
                 color: "error",
-                timeout: timeout
+                timeout
             }
             this.$store.dispatch('setSnackBar', snackbar)
         },
         warningSnackBar(message, timeout = defaultTimeout) {
             const snackbar = {
-                message: message,
+                message,
                 color: "warning",
-                timeout: timeout
+                timeout
             }
             this.$store.dispatch('setSnackBar', snackbar)
         },
         infoSnackBar(message, timeout = 2000) {
             const snackbar = {
-                message: message,
+                message,
                 color: "info",
-                timeout: timeout
+                timeout
             }
             this.$store.dispatch('setSnackBar', snackbar)
         },

--- a/timesketch/frontend-ng/src/store.js
+++ b/timesketch/frontend-ng/src/store.js
@@ -34,7 +34,7 @@ const defaultState = (currentUser) => {
     dataTypes: [],
     count: 0,
     currentSearchNode: null,
-    currentUser: currentUser,
+    currentUser,
     settings: {},
     systemSettings: {},
     activeContext: {
@@ -84,7 +84,7 @@ export default new Vuex.Store({
       Vue.set(state.meta, 'filter_labels', payload)
     },
     SET_DATA_TYPES(state, payload) {
-      let buckets = payload.objects[0]['field_bucket']['buckets']
+      let buckets = payload.objects[0].field_bucket.buckets
       Vue.set(state, 'dataTypes', buckets)
     },
     SET_COUNT(state, payload) {
@@ -94,8 +94,8 @@ export default new Vuex.Store({
       Vue.set(state, 'currentSearchNode', payload)
     },
     SET_SIGMA_LIST(state, payload) {
-      Vue.set(state, 'sigmaRuleList', payload['objects'])
-      Vue.set(state, 'sigmaRuleList_count', payload['meta']['rules_count'])
+      Vue.set(state, 'sigmaRuleList', payload.objects)
+      Vue.set(state, 'sigmaRuleList_count', payload.meta.rules_count)
     },
     SET_VISUALIZATION_LIST(state, payload) {
       Vue.set(state, 'savedVisualizations', payload)
@@ -205,7 +205,7 @@ export default new Vuex.Store({
         .then((response) => {
           context.commit('SET_SKETCH', response.data)
           context.commit('SET_ACTIVE_USER', response.data)
-          context.dispatch('updateTimelineTags', { sketchId: sketchId })
+          context.dispatch('updateTimelineTags', { sketchId })
           context.dispatch('updateDataTypes', sketchId)
         })
         .catch((e) => {
@@ -355,7 +355,7 @@ export default new Vuex.Store({
       }
       return ApiClient.runAggregator(payload.sketchId, formData)
         .then((response) => {
-          let buckets = response.data.objects[0]['field_bucket']['buckets']
+          let buckets = response.data.objects[0].field_bucket.buckets
           if (payload.tag && payload.num) {
             let missing = buckets.find((tag) => tag.tag === payload.tag) === undefined
             if (missing) {

--- a/timesketch/frontend-ng/src/utils/RestApiClient.js
+++ b/timesketch/frontend-ng/src/utils/RestApiClient.js
@@ -20,7 +20,7 @@ const RestApiClient = axios.create({
   baseURL: '/api/v1',
   headers: {
     common: {
-      'X-CSRFToken': document.getElementsByTagName('meta')[0]['content'],
+      'X-CSRFToken': document.getElementsByTagName('meta')[0].content,
     },
   },
 })
@@ -30,7 +30,7 @@ const RestApiBlobClient = axios.create({
   responseType: 'blob',
   headers: {
     common: {
-      'X-CSRFToken': document.getElementsByTagName('meta')[0]['content'],
+      'X-CSRFToken': document.getElementsByTagName('meta')[0].content,
     },
   },
 })
@@ -68,8 +68,8 @@ export default {
   getSketchList(scope, page, perPage, searchQuery) {
     let params = {
       params: {
-        scope: scope,
-        page: page,
+        scope,
+        page,
         per_page: perPage,
         search_query: searchQuery,
       },
@@ -108,9 +108,9 @@ export default {
   },
   addSketchAttribute(sketchId, name, value, ontology) {
     let attribute = {
-      name: name,
+      name,
       values: [value],
-      ontology: ontology,
+      ontology,
       action: 'post',
     }
     return RestApiClient.post('/sketches/' + sketchId + '/attribute/', attribute)
@@ -126,16 +126,16 @@ export default {
   },
   saveSketchTimeline(sketchId, timelineId, name, description, color) {
     let formData = {
-      name: name,
-      description: description,
-      color: color,
+      name,
+      description,
+      color,
     }
     return RestApiClient.post('/sketches/' + sketchId + '/timelines/' + timelineId + '/', formData)
   },
   saveSketchSummary(sketchId, name, description) {
     let formData = {
-      name: name,
-      description: description,
+      name,
+      description,
     }
     return RestApiClient.post('/sketches/' + sketchId + '/', formData)
   },
@@ -145,9 +145,9 @@ export default {
   createEvent(sketchId, datetime, message, timestampDesc, attributes, config) {
     let formData = {
       date_string: datetime,
-      message: message,
+      message,
       timestamp_desc: timestampDesc,
-      attributes: attributes,
+      attributes,
     }
     return RestApiClient.post('/sketches/' + sketchId + '/event/create/', formData, config)
   },
@@ -166,11 +166,11 @@ export default {
   },
   saveEventAnnotation(sketchId, annotationType, annotation, events, currentSearchNode, remove = false, conclusionId = null) {
     let formData = {
-      annotation: annotation,
+      annotation,
       annotation_type: annotationType,
-      events: events,
+      events,
       current_search_node_id: currentSearchNode ? currentSearchNode.id : undefined,
-      remove: remove,
+      remove,
       conclusion_id: conclusionId
     }
     return RestApiClient.post('/sketches/' + sketchId + '/event/annotate/', formData)
@@ -178,7 +178,7 @@ export default {
   tagEvents(sketchId, events, tags) {
     let formData = {
       tag_string: JSON.stringify(tags),
-      events: events,
+      events,
       verbose: false,
     }
     return RestApiClient.post('/sketches/' + sketchId + '/event/tagging/', formData)
@@ -186,15 +186,15 @@ export default {
   untagEvents(sketchId, events, tags) {
     let formData = {
       tags_to_remove: tags,
-      events: events,
+      events,
     }
     return RestApiClient.post('/sketches/' + sketchId + '/event/untag/', formData)
   },
   updateEventAnnotation(sketchId, annotationType, annotation, events, currentSearchNode) {
     let formData = {
-      annotation: annotation,
+      annotation,
       annotation_type: annotationType,
-      events: events,
+      events,
       current_search_node_id: currentSearchNode.id,
     }
     return RestApiClient.put('/sketches/' + sketchId + '/event/annotate/', formData)
@@ -220,15 +220,15 @@ export default {
   },
   createStory(title, content, sketchId) {
     let formData = {
-      title: title,
-      content: content,
+      title,
+      content,
     }
     return RestApiClient.post('/sketches/' + sketchId + '/stories/', formData)
   },
   updateStory(title, content, sketchId, storyId) {
     let formData = {
-      title: title,
-      content: content,
+      title,
+      content,
     }
     return RestApiClient.post('/sketches/' + sketchId + '/stories/' + storyId + '/', formData)
   },
@@ -306,10 +306,10 @@ export default {
   },
   saveAggregation(sketchId, aggregation, name, formData) {
     let newFormData = {
-      name: name,
+      name,
       description: aggregation.description,
       agg_type: aggregation.name,
-      chart_type: formData['supported_charts'] || formData['aggregator_parameters']['chart_type'],
+      chart_type: formData.supported_charts || formData.aggregator_parameters.chart_type,
       parameters: formData,
     }
     return RestApiClient.post('/sketches/' + sketchId + '/aggregation/', newFormData)
@@ -371,13 +371,13 @@ export default {
       config: {
         filter: {
           indices: currentIndices,
-          timelineIds: timelineIds,
+          timelineIds,
         },
       },
-      refresh: refresh,
+      refresh,
     }
     if (timelineIds.length) {
-      formData['timeline_ids'] = timelineIds
+      formData.timeline_ids = timelineIds
     }
     return RestApiClient.post('/sketches/' + sketchId + '/graph/', formData)
   },
@@ -386,8 +386,8 @@ export default {
   },
   saveGraph(sketchId, name, elements) {
     let formData = {
-      name: name,
-      elements: elements,
+      name,
+      elements,
     }
     return RestApiClient.post('/sketches/' + sketchId + '/graphs/', formData)
   },
@@ -426,7 +426,7 @@ export default {
   },
   updateSigmaRule(id, ruleYaml) {
     let formData = {
-      id: id,
+      id,
       rule_yaml: ruleYaml,
     }
     return RestApiClient.put('/sigmarules/' + id + '/', formData)
@@ -439,7 +439,7 @@ export default {
     let params = {}
     if (status) {
       params.params = {
-        status: status,
+        status,
       }
     }
     return RestApiClient.get('/sketches/' + sketchId + '/scenarios/', params)
@@ -453,7 +453,7 @@ export default {
     return RestApiClient.post('/sketches/' + sketchId + '/scenarios/' + scenarioId + '/', formData)
   },
   setScenarioStatus(sketchId, scenarioId, status) {
-    let formData = { status: status }
+    let formData = { status }
     return RestApiClient.post('/sketches/' + sketchId + '/scenarios/' + scenarioId + '/status/', formData)
   },
   getFacets(sketchId, scenarioId) {
@@ -486,11 +486,11 @@ export default {
     return RestApiClient.post('/sketches/' + sketchId + '/questions/', formData)
   },
   createQuestionConclusion(sketchId, questionId, conclusionText) {
-    let formData = { conclusionText: conclusionText }
+    let formData = { conclusionText }
     return RestApiClient.post('/sketches/' + sketchId + '/questions/' + questionId + '/conclusions/', formData)
   },
   editQuestionConclusion(sketchId, questionId, conclusionId, conclusionText) {
-    let formData = { conclusionText: conclusionText }
+    let formData = { conclusionText }
     return RestApiClient.put(
       '/sketches/' + sketchId + '/questions/' + questionId + '/conclusions/' + conclusionId + '/',
       formData
@@ -519,7 +519,7 @@ export default {
   },
   getUnfurlGraph(url) {
     let formData = {
-      url: url,
+      url,
     }
     return RestApiClient.post('/unfurl/', formData)
   },
@@ -530,7 +530,7 @@ export default {
     return RestApiClient.get('/users/me/settings/')
   },
   saveUserSettings(settings) {
-    let formData = { settings: settings }
+    let formData = { settings }
     return RestApiClient.post('/users/me/settings/', formData)
   },
   llmRequest(sketchId, featureName, formData) {

--- a/timesketch/frontend-ng/src/views/Explore.vue
+++ b/timesketch/frontend-ng/src/views/Explore.vue
@@ -461,11 +461,11 @@ export default {
 
     search: function (resetPagination = true, incognito = false, parent = false) {
       let queryRequest = {}
-      queryRequest['queryString'] = this.currentQueryString
-      queryRequest['queryFilter'] = this.currentQueryFilter
-      queryRequest['resetPagination'] = resetPagination
-      queryRequest['incognito'] = incognito
-      queryRequest['parent'] = parent
+      queryRequest.queryString = this.currentQueryString
+      queryRequest.queryFilter = this.currentQueryFilter
+      queryRequest.resetPagination = resetPagination
+      queryRequest.incognito = incognito
+      queryRequest.parent = parent
       this.activeQueryRequest = queryRequest
       this.showSearchDropdown = false
     },

--- a/timesketch/frontend-ng/src/views/Home.vue
+++ b/timesketch/frontend-ng/src/views/Home.vue
@@ -203,7 +203,7 @@ export default {
     document.title = 'Timesketch'
     ApiClient.getScenarioTemplates()
       .then((response) => {
-        this.scenarioTemplates = response.data['objects']
+        this.scenarioTemplates = response.data.objects
       })
       .catch((e) => {})
   },

--- a/timesketch/frontend-ng/src/views/Sketch.vue
+++ b/timesketch/frontend-ng/src/views/Sketch.vue
@@ -560,7 +560,7 @@ export default {
         order: 'asc',
         chips: [startChip],
       }
-      let queryRequest = { queryString: '*', queryFilter: queryFilter }
+      let queryRequest = { queryString: '*', queryFilter }
       return queryRequest
     },
     updateContextQuery(duration) {

--- a/timesketch/frontend-ng/src/views/Story.vue
+++ b/timesketch/frontend-ng/src/views/Story.vue
@@ -419,7 +419,7 @@ export default {
         return []
       }
       return this.$store.state.savedVisualizations.filter(
-          (e) => JSON.parse(e.parameters)['aggregator_class'] === 'apex'
+          (e) => JSON.parse(e.parameters).aggregator_class === 'apex'
       )
     },
     availableSketchQuestions() {
@@ -483,11 +483,11 @@ export default {
 
         queryFilter.size = EVENTS_PER_PAGE
         queryFilter.terminate_after = EVENTS_PER_PAGE
-        queryRequest['queryString'] = queryString
-        queryRequest['queryFilter'] = queryFilter
-        queryRequest['incognito'] = true
+        queryRequest.queryString = queryString
+        queryRequest.queryFilter = queryFilter
+        queryRequest.incognito = true
         return {
-          queryRequest: queryRequest,
+          queryRequest,
           disableSaveSearch: true,
           itemsPerPage: EVENTS_PER_PAGE,
         }

--- a/timesketch/frontend-ng/src/views/ThreatIntel.vue
+++ b/timesketch/frontend-ng/src/views/ThreatIntel.vue
@@ -149,13 +149,13 @@ export default {
       })
     },
     metadataForTag(tag) {
-      let metadata = this.tagMetadata['default'];
+      let metadata = this.tagMetadata.default;
       if (this.tagMetadata[tag]) {
         metadata = this.tagMetadata[tag]
       } else {
-        for (var regex in this.tagMetadata['regexes']) {
+        for (var regex in this.tagMetadata.regexes) {
           if (tag.match(regex)) {
-            metadata = this.tagMetadata['regexes'][regex]
+            metadata = this.tagMetadata.regexes[regex]
           }
         }
       }


### PR DESCRIPTION
Adding a button in the EventList context view to quickly scroll to the specific context event that is requested. This calculates the event's pagination page using the backend `count` flag using the same query minus matching events occurring before the target timestamp based on current sort direction.

---
*PR created automatically by Jules for task [13118913947007987869](https://jules.google.com/task/13118913947007987869) started by @jkppr*