### PR TITLE
Make upload file permission configurable

### DIFF
--- a/data/timesketch.conf
+++ b/data/timesketch.conf
@@ -4,9 +4,6 @@
 # Note: It is a security risk to have this enabled in production.
 DEBUG = False
 
-# File write permission for uploaded files
-UPLOAD_FILE_PERMISSION = 0o600
-
 # Enable performance profiling for all backend requests.
 # Profiling data will be written as .prof files to a `profiles/` directory
 # in either the project root (dev) or /var/log/timesketch/ (release).
@@ -177,6 +174,9 @@ UPLOAD_ENABLED = False
 # Folder for temporarily storage of Plaso dump files before being processed and
 # inserted into the datastore.
 UPLOAD_FOLDER = "/tmp"
+
+# File write permission for uploaded files
+UPLOAD_FILE_PERMISSION = 0o600
 
 # Celery broker configuration. You need to change ip/port to where your Redis
 # server is running.

--- a/data/timesketch.conf
+++ b/data/timesketch.conf
@@ -4,6 +4,9 @@
 # Note: It is a security risk to have this enabled in production.
 DEBUG = False
 
+# File write permission for uploaded files
+UPLOAD_FILE_PERMISSION = 0o600
+
 # Enable performance profiling for all backend requests.
 # Profiling data will be written as .prof files to a `profiles/` directory
 # in either the project root (dev) or /var/log/timesketch/ (release).

--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -485,8 +485,10 @@ class UploadFileResource(resources.ResourceMixin, Resource):
         else:
             file_path = utils.format_upload_path(upload_folder, uuid.uuid4().hex)
 
+        file_permission = current_app.config.get("UPLOAD_FILE_PERMISSION", 0o600)
+
         try:
-            fd = os.open(file_path, os.O_RDWR | os.O_CREAT, 0o600)
+            fd = os.open(file_path, os.O_RDWR | os.O_CREAT, file_permission)
             try:
                 with os.fdopen(fd, "rb+") as fh:
                     fh.seek(chunk_byte_offset)

--- a/timesketch/api/v1/resources_test.py
+++ b/timesketch/api/v1/resources_test.py
@@ -2496,3 +2496,69 @@ class UploadFileResourceTest(BaseTest):
             5,
             "File size mismatch: retry should overwrite, not append",
         )
+
+    @mock.patch("timesketch.api.v1.resources.upload.os.open")
+    @mock.patch("timesketch.api.v1.resources.upload.current_app")
+    @mock.patch("timesketch.api.v1.resources.upload.utils.format_upload_path")
+    def test_upload_file_permission(self, mock_format_upload_path, mock_current_app, mock_os_open):
+        """Test that uploaded files use the configured file permission."""
+        # Set config to a different permission (644 instead of default 600)
+        self.app.config["UPLOAD_FILE_PERMISSION"] = 0o644
+        mock_current_app.config = self.app.config
+
+        import os
+
+        # Setup mock behavior
+        chunk_index_name = "00000000000000000000000000000003"
+        file_path = os.path.join(self.upload_folder, chunk_index_name)
+        mock_format_upload_path.return_value = file_path
+
+        import os
+        # We need a real file descriptor because os.fdopen is called later on the return value.
+        # Save a reference to the real function *before* mocking, or import from a different module.
+        # Since os is patched everywhere, we can use the `open` built-in and get its fd.
+
+        called_with_args = {}
+
+        # Need to keep a reference to avoid GC closing the file
+        f = open(file_path, "wb+")
+        def mock_open(path, flags, mode=0o777, *args, **kwargs):
+            called_with_args['args'] = (path, flags, mode)
+            return f.fileno()
+
+        mock_os_open.side_effect = mock_open
+
+        chunk1 = b"Hello"
+        total_file_size = len(chunk1)
+
+        resource = upload.UploadFileResource()
+        file_storage_mock = mock.MagicMock()
+        sketch_mock = mock.MagicMock()
+        sketch_mock.id = 1
+
+        file_storage_mock.read.return_value = chunk1
+        form_data = {
+            "chunk_index": "0",
+            "chunk_byte_offset": "0",
+            "chunk_total_chunks": "1",
+            "total_file_size": str(total_file_size),
+            "chunk_index_name": chunk_index_name,
+            "name": "test_timeline",
+            "sketch_id": "1",
+        }
+
+        # pylint: disable=protected-access, unused-variable
+        with mock.patch.object(resource, "_upload_and_index") as mock_process:
+            resource._upload_file(
+                file_storage=file_storage_mock,
+                form=form_data,
+                sketch=sketch_mock,
+                index_name="",
+                chunk_index_name=chunk_index_name,
+            )
+
+        # Verify that os.open was called with 0o644
+        self.assertEqual(
+            called_with_args['args'],
+            (file_path, os.O_RDWR | os.O_CREAT, 0o644)
+        )


### PR DESCRIPTION
Make upload file permission configurable

The upload API endpoint previously hardcoded the file permission
to 0o600 when writing uploaded chunks to disk. This caused issues
in setups where the API and Worker roles run on different systems
sharing a mounted disk.

This commit introduces a new configuration option
`UPLOAD_FILE_PERMISSION` in `timesketch.conf`, allowing
administrators to override the default 0o600 permission (e.g. 0o644)
so that other processes or users can read the uploaded files.

A unit test was also added to `UploadFileResourceTest` to ensure
the configuration value is correctly passed to `os.open()`.

---
*PR created automatically by Jules for task [2165998091424842260](https://jules.google.com/task/2165998091424842260) started by @jkppr*