### PR TITLE
feat(model): Ensure newly uploaded timelines have distinct default colors

### DIFF
--- a/timesketch/lib/utils.py
+++ b/timesketch/lib/utils.py
@@ -17,6 +17,7 @@ import colorsys
 import csv
 import datetime
 import email
+import hashlib
 import json
 import logging
 import random
@@ -49,13 +50,23 @@ TIMESKETCH_FIELDS = frozenset({"message", "datetime", "timestamp_desc"})
 REDLINE_FIELDS = frozenset({"Alert", "Tag", "Timestamp", "Field", "Summary"})
 
 
-def random_color():
+def random_color(seed: Optional[str] = None):
     """Generates a random color.
+
+    Args:
+        seed: Optional string to use as a seed for the random color.
+              This guarantees that the same seed will always produce
+              the same color.
 
     Returns:
         Color as string in HEX
     """
-    hue = random.random()
+    if seed:
+        h = int(hashlib.md5(seed.encode("utf-8")).hexdigest(), 16)
+        hue = (h % 1000) / 1000.0
+    else:
+        hue = random.random()
+
     golden_ratio_conjugate = (1 + 5**0.5) / 2
     hue += golden_ratio_conjugate
     hue %= 1

--- a/timesketch/lib/utils_test.py
+++ b/timesketch/lib/utils_test.py
@@ -42,6 +42,16 @@ class TestUtils(BaseTest):
         color = random_color()
         self.assertTrue(re.match("^[0-9a-fA-F]{6}$", color))
 
+        color2 = random_color(seed="test_timeline")
+        self.assertTrue(re.match("^[0-9a-fA-F]{6}$", color2))
+
+        color3 = random_color(seed="test_timeline")
+        self.assertEqual(color2, color3)
+
+        color4 = random_color(seed="test_timeline_2")
+        self.assertTrue(re.match("^[0-9a-fA-F]{6}$", color4))
+        self.assertNotEqual(color2, color4)
+
     def test_get_validated_indices(self):
         """Test for validating indices."""
         sketch = self.sketch1

--- a/timesketch/models/sketch.py
+++ b/timesketch/models/sketch.py
@@ -46,6 +46,23 @@ from timesketch.models import db_session
 logger = logging.getLogger("timesketch.sketch")
 
 
+def _timeline_color_default(context):
+    """Returns a deterministic random color for a timeline.
+
+    The color is computed based on the timeline's name.
+
+    Args:
+        context: The SQLAlchemy context.
+
+    Returns:
+        Color as a HEX string.
+    """
+    timeline_name = context.current_parameters.get("name")
+    if timeline_name:
+        return random_color(seed=timeline_name)
+    return random_color()
+
+
 class Sketch(AccessControlMixin, LabelMixin, StatusMixin, CommentMixin, BaseModel):
     """Implements the Sketch model.
 
@@ -269,7 +286,7 @@ class Timeline(LabelMixin, StatusMixin, CommentMixin, BaseModel):
 
     name = Column(Unicode(255))
     description = Column(UnicodeText())
-    color = Column(Unicode(6), default=random_color())
+    color = Column(Unicode(6), default=_timeline_color_default)
     user_id = Column(Integer, ForeignKey("user.id"))
     searchindex_id = Column(Integer, ForeignKey("searchindex.id"))
     sketch_id = Column(Integer, ForeignKey("sketch.id"))


### PR DESCRIPTION
This PR addresses an issue where multiple timelines uploaded around the same time would receive identical or very similar colors (e.g., shades of green). This was caused by `random_color()` being evaluated once at import time or seeded with similar timestamps.

### Changes:
1. Updated `timesketch/lib/utils.py:random_color` to optionally accept a `seed`. When a seed is provided, it uses `hashlib.md5` to deterministically generate a stable hue for the color.
2. Updated the `Timeline` SQLAlchemy model to use a callable `_timeline_color_default` that accesses `context.current_parameters['name']` and uses it as the seed for `random_color`.
3. Verified the changes with updated unit tests in `timesketch/lib/utils_test.py`.

---
*PR created automatically by Jules for task [745144177529782320](https://jules.google.com/task/745144177529782320) started by @jkppr*